### PR TITLE
[GH-321] Moved all modules from Structures

### DIFF
--- a/.iex.exs
+++ b/.iex.exs
@@ -1,13 +1,16 @@
 alias Aecore.Chain.Worker, as: Chain
-alias Aecore.Chain.{ChainState, BlockValidation, Difficulty}
+alias Aecore.Chain.{ChainState, BlockValidation, Difficulty, Block, Header}
 alias Aecore.Miner.Worker, as: Miner
 alias Aecore.Oracle.Oracle
+alias Aecore.Oracle.Tx.{OracleExtendTx, OracleQueryTx, OracleRegistrationTx, OracleResponseTx}
 alias Aecore.Peers.{PeerBlocksTask, Scheduler, Sync}
 alias Aecore.Peers.Worker, as: Peers
 alias Aecore.Persistance.Worker, as: Persistance
 alias Aecore.Pow.{Cuckoo, Hashcash}
-alias Aecore.Structures.{Account, Block, DataTx, Header, OracleExtendTx, OracleQueryTx, OracleRegistrationTx, OracleResponseTx, SignedTx, SpendTx}
-alias Aecore.Txs.Pool.Worker, as: Pool
+alias Aecore.Account.Account
+alias Aecore.Account.Tx.SpendTx
+alias Aecore.Tx.{DataTx, SignedTx}
+alias Aecore.Tx.Pool.Worker, as: Pool
 alias Aecore.Wallet.Worker, as: Wallet
 
 alias Aehttpclient.Client

--- a/.iex.exs
+++ b/.iex.exs
@@ -1,5 +1,5 @@
 alias Aecore.Chain.Worker, as: Chain
-alias Aecore.Chain.{ChainState, BlockValidation, Difficulty, Block, Header}
+alias Aecore.Chain.{Chainstate, BlockValidation, Difficulty, Block, Header}
 alias Aecore.Miner.Worker, as: Miner
 alias Aecore.Oracle.Oracle
 alias Aecore.Oracle.Tx.{OracleExtendTx, OracleQueryTx, OracleRegistrationTx, OracleResponseTx}
@@ -7,7 +7,7 @@ alias Aecore.Peers.{PeerBlocksTask, Scheduler, Sync}
 alias Aecore.Peers.Worker, as: Peers
 alias Aecore.Persistance.Worker, as: Persistance
 alias Aecore.Pow.{Cuckoo, Hashcash}
-alias Aecore.Account.Account
+alias Aecore.Account.{Account, AccountStateTree}
 alias Aecore.Account.Tx.SpendTx
 alias Aecore.Tx.{DataTx, SignedTx}
 alias Aecore.Tx.Pool.Worker, as: Pool

--- a/apps/aecore/lib/aecore.ex
+++ b/apps/aecore/lib/aecore.ex
@@ -12,7 +12,7 @@ defmodule Aecore do
       Aecore.Persistence.Worker.Supervisor,
       Aecore.Chain.Worker.Supervisor,
       Aecore.Miner.Worker.Supervisor,
-      Aecore.Txs.Pool.Worker.Supervisor,
+      Aecore.Tx.Pool.Worker.Supervisor,
       Aecore.Peers.Worker.Supervisor,
       Aecore.Wallet.Worker.Supervisor,
       supervisor(Exexec, [], function: :start)

--- a/apps/aecore/lib/aecore/account/account.ex
+++ b/apps/aecore/lib/aecore/account/account.ex
@@ -1,4 +1,4 @@
-defmodule Aecore.Structures.Account do
+defmodule Aecore.Account.Account do
   @moduledoc """
   Aecore structure of a transaction data.
   """
@@ -7,12 +7,12 @@ defmodule Aecore.Structures.Account do
 
   alias Aecore.Wallet.Worker, as: Wallet
   alias Aecore.Chain.Worker, as: Chain
-  alias Aecore.Structures.SpendTx
-  alias Aecore.Structures.Account
+  alias Aecore.Account.Tx.SpendTx
+  alias Aecore.Account.Account
   alias Aeutil.Bits
-  alias Aecore.Structures.DataTx
-  alias Aecore.Structures.SignedTx
-  alias Aecore.Structures.AccountStateTree
+  alias Aecore.Tx.DataTx
+  alias Aecore.Tx.SignedTx
+  alias Aecore.Account.AccountStateTree
 
   @type t :: %Account{
           balance: non_neg_integer(),

--- a/apps/aecore/lib/aecore/account/account_state_tree.ex
+++ b/apps/aecore/lib/aecore/account/account_state_tree.ex
@@ -1,8 +1,8 @@
-defmodule Aecore.Structures.AccountStateTree do
+defmodule Aecore.Account.AccountStateTree do
   @moduledoc """
   Top level account state tree.
   """
-  alias Aecore.Structures.Account
+  alias Aecore.Account.Account
   alias Aecore.Wallet.Worker, as: Wallet
   alias Aeutil.Serialization
   @type encoded_account_state :: binary()

--- a/apps/aecore/lib/aecore/account/tx/spend_tx.ex
+++ b/apps/aecore/lib/aecore/account/tx/spend_tx.ex
@@ -1,16 +1,16 @@
-defmodule Aecore.Structures.SpendTx do
+defmodule Aecore.Account.Tx.SpendTx do
   @moduledoc """
   Aecore structure of a transaction data.
   """
 
-  @behaviour Aecore.Structures.Transaction
-  alias Aecore.Structures.SpendTx
-  alias Aecore.Structures.Account
+  @behaviour Aecore.Tx.Transaction
+  alias Aecore.Account.Tx.SpendTx
+  alias Aecore.Account.Account
   alias Aecore.Wallet
-  alias Aecore.Structures.Account
-  alias Aecore.Structures.Chainstate
-  alias Aecore.Structures.AccountStateTree
-  alias Aecore.Txs.Pool.Worker, as: Pool
+  alias Aecore.Account.Account
+  alias Aecore.Chain.Chainstate
+  alias Aecore.Account.AccountStateTree
+  alias Aecore.Tx.Pool.Worker, as: Pool
 
   require Logger
 

--- a/apps/aecore/lib/aecore/chain/block.ex
+++ b/apps/aecore/lib/aecore/chain/block.ex
@@ -1,10 +1,10 @@
-defmodule Aecore.Structures.Block do
+defmodule Aecore.Chain.Block do
   @moduledoc """
   Structure of the block
   """
-  alias Aecore.Structures.Block
-  alias Aecore.Structures.Header
-  alias Aecore.Structures.SignedTx
+  alias Aecore.Chain.Block
+  alias Aecore.Chain.Header
+  alias Aecore.Tx.SignedTx
 
   @type t :: %Block{
           header: Header.t(),

--- a/apps/aecore/lib/aecore/chain/block_validation.ex
+++ b/apps/aecore/lib/aecore/chain/block_validation.ex
@@ -5,11 +5,11 @@ defmodule Aecore.Chain.BlockValidation do
 
   alias Aecore.Pow.Cuckoo
   alias Aecore.Miner.Worker, as: Miner
-  alias Aecore.Structures.Block
-  alias Aecore.Structures.Header
-  alias Aecore.Structures.SignedTx
-  alias Aecore.Structures.SpendTx
-  alias Aecore.Structures.Chainstate
+  alias Aecore.Chain.Block
+  alias Aecore.Chain.Header
+  alias Aecore.Tx.SignedTx
+  alias Aecore.Account.Tx.SpendTx
+  alias Aecore.Chain.Chainstate
   alias Aecore.Chain.Difficulty
   alias Aeutil.Serialization
 

--- a/apps/aecore/lib/aecore/chain/chainstate.ex
+++ b/apps/aecore/lib/aecore/chain/chainstate.ex
@@ -1,14 +1,14 @@
-defmodule Aecore.Structures.Chainstate do
+defmodule Aecore.Chain.Chainstate do
   @moduledoc """
   Module used for calculating the block and chain states.
   The chain state is a map, telling us what amount of tokens each account has.
   """
 
-  alias Aecore.Structures.SignedTx
-  alias Aecore.Structures.DataTx
-  alias Aecore.Structures.Account
-  alias Aecore.Structures.AccountStateTree
-  alias Aecore.Structures.Chainstate
+  alias Aecore.Tx.SignedTx
+  alias Aecore.Tx.DataTx
+  alias Aecore.Account.Account
+  alias Aecore.Account.AccountStateTree
+  alias Aecore.Chain.Chainstate
   alias Aeutil.Bits
   alias Aecore.Oracle.Oracle
 

--- a/apps/aecore/lib/aecore/chain/difficulty.ex
+++ b/apps/aecore/lib/aecore/chain/difficulty.ex
@@ -3,7 +3,7 @@ defmodule Aecore.Chain.Difficulty do
   Contains functions used to calculate the PoW difficulty.
   """
 
-  alias Aecore.Structures.Block
+  alias Aecore.Chain.Block
   alias Aeutil.Scientific
 
   use Bitwise

--- a/apps/aecore/lib/aecore/chain/header.ex
+++ b/apps/aecore/lib/aecore/chain/header.ex
@@ -1,9 +1,9 @@
-defmodule Aecore.Structures.Header do
+defmodule Aecore.Chain.Header do
   @moduledoc """
   Structure of Header
   """
 
-  alias Aecore.Structures.Header
+  alias Aecore.Chain.Header
   alias Aeutil.Bits
 
   @type t :: %Header{

--- a/apps/aecore/lib/aecore/chain/worker.ex
+++ b/apps/aecore/lib/aecore/chain/worker.ex
@@ -6,16 +6,16 @@ defmodule Aecore.Chain.Worker do
   use GenServer
   use Bitwise
 
-  alias Aecore.Structures.Block
-  alias Aecore.Structures.SpendTx
+  alias Aecore.Chain.Block
+  alias Aecore.Account.Tx.SpendTx
   alias Aecore.Oracle.Oracle
-  alias Aecore.Structures.OracleRegistrationTx
-  alias Aecore.Structures.OracleQueryTx
-  alias Aecore.Structures.OracleResponseTx
-  alias Aecore.Structures.OracleExtendTx
-  alias Aecore.Structures.Header
-  alias Aecore.Structures.SpendTx
-  alias Aecore.Txs.Pool.Worker, as: Pool
+  alias Aecore.Oracle.Tx.OracleRegistrationTx
+  alias Aecore.Oracle.Tx.OracleQueryTx
+  alias Aecore.Oracle.Tx.OracleResponseTx
+  alias Aecore.Oracle.Tx.OracleExtendTx
+  alias Aecore.Chain.Header
+  alias Aecore.Account.Tx.SpendTx
+  alias Aecore.Tx.Pool.Worker, as: Pool
   alias Aecore.Chain.BlockValidation
   alias Aecore.Peers.Worker, as: Peers
   alias Aecore.Persistence.Worker, as: Persistence
@@ -23,9 +23,9 @@ defmodule Aecore.Chain.Worker do
   alias Aecore.Wallet.Worker, as: Wallet
   alias Aehttpserver.Web.Notify
   alias Aeutil.Serialization
-  alias Aecore.Structures.Chainstate
-  alias Aecore.Structures.Account
-  alias Aecore.Structures.AccountStateTree
+  alias Aecore.Chain.Chainstate
+  alias Aecore.Account.Account
+  alias Aecore.Account.AccountStateTree
 
   require Logger
 

--- a/apps/aecore/lib/aecore/miner/worker.ex
+++ b/apps/aecore/lib/aecore/miner/worker.ex
@@ -9,15 +9,15 @@ defmodule Aecore.Miner.Worker do
   alias Aecore.Chain.Worker, as: Chain
   alias Aecore.Chain.BlockValidation
   alias Aecore.Chain.Difficulty
-  alias Aecore.Structures.Header
-  alias Aecore.Structures.Block
+  alias Aecore.Chain.Header
+  alias Aecore.Chain.Block
   alias Aecore.Pow.Cuckoo
   alias Aecore.Oracle.Oracle
-  alias Aecore.Structures.DataTx
-  alias Aecore.Structures.SpendTx
-  alias Aecore.Structures.SignedTx
-  alias Aecore.Structures.Chainstate
-  alias Aecore.Txs.Pool.Worker, as: Pool
+  alias Aecore.Tx.DataTx
+  alias Aecore.Account.Tx.SpendTx
+  alias Aecore.Tx.SignedTx
+  alias Aecore.Chain.Chainstate
+  alias Aecore.Tx.Pool.Worker, as: Pool
   alias Aecore.Peers.Worker, as: Peers
   alias Aecore.Wallet.Worker, as: Wallet
 

--- a/apps/aecore/lib/aecore/oracle/oracle.ex
+++ b/apps/aecore/lib/aecore/oracle/oracle.ex
@@ -3,16 +3,16 @@ defmodule Aecore.Oracle.Oracle do
   Contains wrapping functions for working with oracles, data validation and TTL calculations.
   """
 
-  alias Aecore.Structures.OracleRegistrationTx
-  alias Aecore.Structures.OracleQueryTx
-  alias Aecore.Structures.OracleResponseTx
-  alias Aecore.Structures.OracleExtendTx
-  alias Aecore.Structures.DataTx
-  alias Aecore.Structures.SignedTx
-  alias Aecore.Txs.Pool.Worker, as: Pool
+  alias Aecore.Oracle.Tx.OracleRegistrationTx
+  alias Aecore.Oracle.Tx.OracleQueryTx
+  alias Aecore.Oracle.Tx.OracleResponseTx
+  alias Aecore.Oracle.Tx.OracleExtendTx
+  alias Aecore.Tx.DataTx
+  alias Aecore.Tx.SignedTx
+  alias Aecore.Tx.Pool.Worker, as: Pool
   alias Aecore.Wallet.Worker, as: Wallet
   alias Aecore.Chain.Worker, as: Chain
-  alias Aecore.Structures.Account
+  alias Aecore.Account.Account
   alias ExJsonSchema.Schema, as: JsonSchema
   alias ExJsonSchema.Validator, as: JsonValidator
 

--- a/apps/aecore/lib/aecore/oracle/tx/oracle_extend_tx.ex
+++ b/apps/aecore/lib/aecore/oracle/tx/oracle_extend_tx.ex
@@ -1,14 +1,14 @@
-defmodule Aecore.Structures.OracleExtendTx do
+defmodule Aecore.Oracle.Tx.OracleExtendTx do
   @moduledoc """
   Contains the transaction structure for oracle extensions
   and functions associated with those transactions.
   """
 
-  @behaviour Aecore.Structures.Transaction
+  @behaviour Aecore.Tx.Transaction
 
   alias __MODULE__
   alias Aecore.Oracle.Oracle
-  alias Aecore.Structures.Account
+  alias Aecore.Account.Account
   alias Aecore.Wallet.Worker, as: Wallet
 
   require Logger

--- a/apps/aecore/lib/aecore/oracle/tx/oracle_query_tx.ex
+++ b/apps/aecore/lib/aecore/oracle/tx/oracle_query_tx.ex
@@ -1,19 +1,19 @@
-defmodule Aecore.Structures.OracleQueryTx do
+defmodule Aecore.Oracle.Tx.OracleQueryTx do
   @moduledoc """
   Contains the transaction structure for oracle queries
   and functions associated with those transactions.
   """
 
-  @behaviour Aecore.Structures.Transaction
+  @behaviour Aecore.Tx.Transaction
 
   alias __MODULE__
-  alias Aecore.Structures.Account
+  alias Aecore.Account.Account
   alias Aecore.Wallet.Worker, as: Wallet
   alias Aecore.Chain.Worker, as: Chain
   alias Aecore.Oracle.Oracle
-  alias Aecore.Structures.Chainstate
+  alias Aecore.Chain.Chainstate
   alias Aeutil.Bits
-  alias Aecore.Structures.AccountStateTree
+  alias Aecore.Account.AccountStateTree
 
   require Logger
 

--- a/apps/aecore/lib/aecore/oracle/tx/oracle_registration_tx.ex
+++ b/apps/aecore/lib/aecore/oracle/tx/oracle_registration_tx.ex
@@ -1,16 +1,16 @@
-defmodule Aecore.Structures.OracleRegistrationTx do
+defmodule Aecore.Oracle.Tx.OracleRegistrationTx do
   @moduledoc """
   Contains the transaction structure for oracle registration
   and functions associated with those transactions.
   """
 
   alias __MODULE__
-  alias Aecore.Structures.Account
+  alias Aecore.Account.Account
   alias Aecore.Wallet.Worker, as: Wallet
   alias Aecore.Oracle.Oracle
   alias ExJsonSchema.Schema, as: JsonSchema
-  alias Aecore.Structures.Chainstate
-  alias Aecore.Structures.AccountStateTree
+  alias Aecore.Chain.Chainstate
+  alias Aecore.Account.AccountStateTree
 
   require Logger
 

--- a/apps/aecore/lib/aecore/oracle/tx/oracle_response_tx.ex
+++ b/apps/aecore/lib/aecore/oracle/tx/oracle_response_tx.ex
@@ -1,4 +1,4 @@
-defmodule Aecore.Structures.OracleResponseTx do
+defmodule Aecore.Oracle.Tx.OracleResponseTx do
   @moduledoc """
   Contains the transaction structure for oracle responses
   and functions associated with those transactions.
@@ -8,9 +8,9 @@ defmodule Aecore.Structures.OracleResponseTx do
   alias Aecore.Oracle.Oracle
   alias Aecore.Chain.Worker, as: Chain
   alias Aecore.Wallet.Worker, as: Wallet
-  alias Aecore.Structures.Chainstate
-  alias Aecore.Structures.Account
-  alias Aecore.Structures.AccountStateTree
+  alias Aecore.Chain.Chainstate
+  alias Aecore.Account.Account
+  alias Aecore.Account.AccountStateTree
 
   require Logger
 

--- a/apps/aecore/lib/aecore/peers/sync.ex
+++ b/apps/aecore/lib/aecore/peers/sync.ex
@@ -8,11 +8,11 @@ defmodule Aecore.Peers.Sync do
   alias Aecore.Peers.Worker, as: Peers
   alias Aehttpclient.Client, as: HttpClient
   alias Aecore.Chain.Worker, as: Chain
-  alias Aecore.Structures.Header
-  alias Aecore.Txs.Pool.Worker, as: Pool
+  alias Aecore.Chain.Header
+  alias Aecore.Tx.Pool.Worker, as: Pool
   alias Aecore.Chain.BlockValidation
   alias Aecore.Peers.PeerBlocksTask
-  alias Aecore.Structures.Header
+  alias Aecore.Chain.Header
 
   require Logger
 

--- a/apps/aecore/lib/aecore/peers/worker.ex
+++ b/apps/aecore/lib/aecore/peers/worker.ex
@@ -8,11 +8,11 @@ defmodule Aecore.Peers.Worker do
   alias Aecore.Peers.Sync
   alias Aehttpclient.Client
   alias Aecore.Chain.Worker, as: Chain
-  alias Aecore.Structures.Block
-  alias Aecore.Structures.SignedTx
-  alias Aecore.Structures.Header
+  alias Aecore.Chain.Block
+  alias Aecore.Tx.SignedTx
+  alias Aecore.Chain.Header
   alias Aecore.Chain.BlockValidation
-  alias Aecore.Structures.Header
+  alias Aecore.Chain.Header
 
   require Logger
 

--- a/apps/aecore/lib/aecore/persistence/worker.ex
+++ b/apps/aecore/lib/aecore/persistence/worker.ex
@@ -8,7 +8,7 @@ defmodule Aecore.Persistence.Worker do
 
   alias Rox.Batch
   alias Aecore.Chain.BlockValidation
-  alias Aecore.Structures.AccountStateTree
+  alias Aecore.Account.AccountStateTree
 
   require Logger
 

--- a/apps/aecore/lib/aecore/pow/cuckoo.ex
+++ b/apps/aecore/lib/aecore/pow/cuckoo.ex
@@ -12,7 +12,7 @@ defmodule Aecore.Pow.Cuckoo do
   require Logger
 
   alias Aecore.Chain.BlockValidation
-  alias Aecore.Structures.Header
+  alias Aecore.Chain.Header
   alias Aecore.Pow.Hashcash
 
   @doc """

--- a/apps/aecore/lib/aecore/pow/hashcash.ex
+++ b/apps/aecore/lib/aecore/pow/hashcash.ex
@@ -5,7 +5,7 @@ defmodule Aecore.Pow.Hashcash do
 
   alias Aeutil.Scientific
   alias Aecore.Chain.BlockValidation
-  alias Aecore.Structures.Header
+  alias Aecore.Chain.Header
 
   use Bitwise
 
@@ -13,7 +13,7 @@ defmodule Aecore.Pow.Hashcash do
   Verify a nonce, returns :true | :false
   """
   @spec verify(map()) :: boolean()
-  def verify(%Aecore.Structures.Header{} = block_header) do
+  def verify(%Aecore.Chain.Header{} = block_header) do
     block_header_hash = BlockValidation.block_header_hash(block_header)
     verify(block_header_hash, block_header.target)
   end

--- a/apps/aecore/lib/aecore/tx/data_tx.ex
+++ b/apps/aecore/lib/aecore/tx/data_tx.ex
@@ -1,14 +1,14 @@
-defmodule Aecore.Structures.DataTx do
+defmodule Aecore.Tx.DataTx do
   @moduledoc """
   Aecore structure of a transaction data.
   """
 
-  alias Aecore.Structures.DataTx
-  alias Aecore.Structures.Chainstate
-  alias Aecore.Structures.SpendTx
+  alias Aecore.Tx.DataTx
+  alias Aecore.Chain.Chainstate
+  alias Aecore.Account.Tx.SpendTx
   alias Aeutil.Serialization
   alias Aeutil.Parser
-  alias Aecore.Structures.Account
+  alias Aecore.Account.Account
 
   require Logger
 

--- a/apps/aecore/lib/aecore/tx/pool/worker.ex
+++ b/apps/aecore/lib/aecore/tx/pool/worker.ex
@@ -1,4 +1,4 @@
-defmodule Aecore.Txs.Pool.Worker do
+defmodule Aecore.Tx.Pool.Worker do
   @moduledoc """
   Module for working with the transaction pool.
   The pool itself is a map with an empty initial state.
@@ -6,18 +6,18 @@ defmodule Aecore.Txs.Pool.Worker do
 
   use GenServer
 
-  alias Aecore.Structures.SignedTx
-  alias Aecore.Structures.Block
-  alias Aecore.Structures.SpendTx
-  alias Aecore.Structures.OracleRegistrationTx
-  alias Aecore.Structures.OracleQueryTx
-  alias Aecore.Structures.OracleResponseTx
-  alias Aecore.Structures.OracleExtendTx
+  alias Aecore.Tx.SignedTx
+  alias Aecore.Chain.Block
+  alias Aecore.Account.Tx.SpendTx
+  alias Aecore.Oracle.Tx.OracleRegistrationTx
+  alias Aecore.Oracle.Tx.OracleQueryTx
+  alias Aecore.Oracle.Tx.OracleResponseTx
+  alias Aecore.Oracle.Tx.OracleExtendTx
   alias Aecore.Chain.BlockValidation
   alias Aecore.Peers.Worker, as: Peers
   alias Aecore.Chain.Worker, as: Chain
   alias Aeutil.Serialization
-  alias Aecore.Structures.DataTx
+  alias Aecore.Tx.DataTx
   alias Aehttpserver.Web.Notify
 
   require Logger

--- a/apps/aecore/lib/aecore/tx/pool/worker/supervisor.ex
+++ b/apps/aecore/lib/aecore/tx/pool/worker/supervisor.ex
@@ -1,4 +1,4 @@
-defmodule Aecore.Txs.Pool.Worker.Supervisor do
+defmodule Aecore.Tx.Pool.Worker.Supervisor do
   @moduledoc """
   Supervisor responsible for all of the worker modules in his folder
   """
@@ -11,7 +11,7 @@ defmodule Aecore.Txs.Pool.Worker.Supervisor do
 
   def init(:ok) do
     children = [
-      Aecore.Txs.Pool.Worker
+      Aecore.Tx.Pool.Worker
     ]
 
     Supervisor.init(children, strategy: :one_for_one)

--- a/apps/aecore/lib/aecore/tx/signed_tx.ex
+++ b/apps/aecore/lib/aecore/tx/signed_tx.ex
@@ -1,11 +1,11 @@
-defmodule Aecore.Structures.SignedTx do
+defmodule Aecore.Tx.SignedTx do
   @moduledoc """
   Aecore structure of a signed transaction.
   """
 
-  alias Aecore.Structures.SignedTx
-  alias Aecore.Structures.DataTx
-  alias Aecore.Structures.SignedTx
+  alias Aecore.Tx.SignedTx
+  alias Aecore.Tx.DataTx
+  alias Aecore.Tx.SignedTx
   alias Aewallet.Signing
   alias Aeutil.Serialization
   alias Aeutil.Bits

--- a/apps/aecore/lib/aecore/tx/transaction.ex
+++ b/apps/aecore/lib/aecore/tx/transaction.ex
@@ -1,12 +1,12 @@
-defmodule Aecore.Structures.Transaction do
+defmodule Aecore.Tx.Transaction do
   @moduledoc """
   Behaviour that states all the necessary functions that every custom transaction,
   child tx of DataTx should implement to work correctly on the blockchain
   """
 
-  alias Aecore.Structures.SpendTx
-  alias Aecore.Structures.Account
-  alias Aecore.Structures.Chainstate
+  alias Aecore.Account.Tx.SpendTx
+  alias Aecore.Account.Account
+  alias Aecore.Chain.Chainstate
   alias Aecore.Wallet.Worker, as: Wallet
 
   @typedoc "Arbitrary map holding all the specific elements required

--- a/apps/aecore/test/aecore_chain_state_test.exs
+++ b/apps/aecore/test/aecore_chain_state_test.exs
@@ -5,12 +5,12 @@ defmodule AecoreChainstateTest do
 
   use ExUnit.Case
 
-  alias Aecore.Structures.Account
+  alias Aecore.Account.Account
   alias Aecore.Chain.Worker, as: Chain
   alias Aecore.Persistence.Worker, as: Persistence
   alias Aecore.Wallet.Worker, as: Wallet
-  alias Aecore.Structures.AccountStateTree
-  alias Aecore.Structures.Chainstate
+  alias Aecore.Account.AccountStateTree
+  alias Aecore.Chain.Chainstate
 
   setup do
     on_exit(fn ->

--- a/apps/aecore/test/aecore_chain_test.exs
+++ b/apps/aecore/test/aecore_chain_test.exs
@@ -6,9 +6,9 @@ defmodule AecoreChainTest do
   use ExUnit.Case
 
   alias Aecore.Persistence.Worker, as: Persistence
-  alias Aecore.Structures.Chainstate
-  alias Aecore.Structures.Block
-  alias Aecore.Structures.Header
+  alias Aecore.Chain.Chainstate
+  alias Aecore.Chain.Block
+  alias Aecore.Chain.Header
   alias Aecore.Chain.BlockValidation
   alias Aecore.Chain.Worker, as: Chain
   alias Aecore.Miner.Worker, as: Miner

--- a/apps/aecore/test/aecore_difficulty_test.exs
+++ b/apps/aecore/test/aecore_difficulty_test.exs
@@ -4,8 +4,8 @@ defmodule DifficultyTest do
   doctest Aecore.Chain.Difficulty
 
   alias Aecore.Chain.Difficulty, as: Difficulty
-  alias Aecore.Structures.Block
-  alias Aecore.Structures.Header
+  alias Aecore.Chain.Block
+  alias Aecore.Chain.Header
 
   @tag :difficulty
   test "difficulty calculation genesis block only" do

--- a/apps/aecore/test/aecore_get_txs_for_address.exs
+++ b/apps/aecore/test/aecore_get_txs_for_address.exs
@@ -3,11 +3,11 @@ defmodule GetTxsForAddressTest do
 
   alias Aecore.Persistence.Worker, as: Persistence
   alias Aecore.Chain.Worker, as: Chain
-  alias Aecore.Structures.SpendTx, as: SpendTx
+  alias Aecore.Account.Tx.SpendTx, as: SpendTx
   alias Aecore.Wallet.Worker, as: Wallet
   alias Aecore.Miner.Worker, as: Miner
   alias Aecore.Chain.BlockValidation, as: BlockValidation
-  alias Aecore.Txs.Pool.Worker, as: Pool
+  alias Aecore.Tx.Pool.Worker, as: Pool
   alias Aeutil.Serialization
 
   setup do

--- a/apps/aecore/test/aecore_hashcash_test.exs
+++ b/apps/aecore/test/aecore_hashcash_test.exs
@@ -3,8 +3,8 @@ defmodule HashcashTest do
   doctest Aecore.Pow.Hashcash
 
   # alias Aecore.Pow.Hashcash
-  # alias Aecore.Structures.Header
-  # alias Aecore.Structures.Block
+  # alias Aecore.Chain.Header
+  # alias Aecore.Chain.Block
 
   # @tag timeout: 10000000
   # test "successfull test" do

--- a/apps/aecore/test/aecore_miner_test.exs
+++ b/apps/aecore/test/aecore_miner_test.exs
@@ -2,7 +2,7 @@ defmodule MinerTest do
   use ExUnit.Case
 
   alias Aecore.Persistence.Worker, as: Persistence
-  alias Aecore.Structures.SignedTx
+  alias Aecore.Tx.SignedTx
   alias Aecore.Chain.Worker, as: Chain
   alias Aecore.Miner.Worker, as: Miner
 

--- a/apps/aecore/test/aecore_oracle_test.exs
+++ b/apps/aecore/test/aecore_oracle_test.exs
@@ -4,7 +4,7 @@ defmodule AecoreOracleTest do
   alias Aecore.Oracle.Oracle
   alias Aecore.Chain.Worker, as: Chain
   alias Aecore.Miner.Worker, as: Miner
-  alias Aecore.Txs.Pool.Worker, as: Pool
+  alias Aecore.Tx.Pool.Worker, as: Pool
 
   @tag timeout: 120_000
   test "register and query an oracle, check response, check if invalid transactions are filtered out" do

--- a/apps/aecore/test/aecore_pow_cuckoo_test.exs
+++ b/apps/aecore/test/aecore_pow_cuckoo_test.exs
@@ -9,11 +9,11 @@ defmodule AecoreCuckooTest do
 
   alias Aecore.Persistence.Worker, as: Persistence
   alias Aecore.Pow.Cuckoo
-  alias Aecore.Structures.Block
-  alias Aecore.Structures.Header
-  alias Aecore.Structures.SignedTx
-  alias Aecore.Structures.DataTx
-  alias Aecore.Structures.SpendTx
+  alias Aecore.Chain.Block
+  alias Aecore.Chain.Header
+  alias Aecore.Tx.SignedTx
+  alias Aecore.Tx.DataTx
+  alias Aecore.Account.Tx.SpendTx
 
   setup do
     on_exit(fn ->

--- a/apps/aecore/test/aecore_tx_test.exs
+++ b/apps/aecore/test/aecore_tx_test.exs
@@ -1,6 +1,6 @@
 defmodule AecoreTxTest do
   @moduledoc """
-  Unit tests for the Aecore.Txs.Tx module
+  Unit tests for the Aecore.Tx.Tx module
   """
 
   use ExUnit.Case
@@ -8,15 +8,15 @@ defmodule AecoreTxTest do
   alias Aecore.Persistence.Worker, as: Persistence
   alias Aecore.Chain.Worker, as: Chain
   alias Aecore.Miner.Worker, as: Miner
-  alias Aecore.Txs.Pool.Worker, as: Pool
-  alias Aecore.Structures.SignedTx
-  alias Aecore.Structures.DataTx
-  alias Aecore.Structures.SpendTx
+  alias Aecore.Tx.Pool.Worker, as: Pool
+  alias Aecore.Tx.SignedTx
+  alias Aecore.Tx.DataTx
+  alias Aecore.Account.Tx.SpendTx
   alias Aecore.Wallet.Worker, as: Wallet
   alias Aewallet.Signing
   alias Aeutil.Serialization
-  alias Aecore.Structures.AccountStateTree
-  alias Aecore.Structures.Account
+  alias Aecore.Account.AccountStateTree
+  alias Aecore.Account.Account
 
   setup do
     Code.require_file("test_utils.ex", "./test")

--- a/apps/aecore/test/aecore_txs_pool_test.exs
+++ b/apps/aecore/test/aecore_txs_pool_test.exs
@@ -5,14 +5,14 @@ defmodule AecoreTxsPoolTest do
   use ExUnit.Case
 
   alias Aecore.Persistence.Worker, as: Persistence
-  alias Aecore.Txs.Pool.Worker, as: Pool
+  alias Aecore.Tx.Pool.Worker, as: Pool
   alias Aecore.Miner.Worker, as: Miner
   alias Aecore.Chain.Worker, as: Chain
-  alias Aecore.Structures.SignedTx
-  alias Aecore.Structures.SpendTx
-  alias Aecore.Structures.DataTx
+  alias Aecore.Tx.SignedTx
+  alias Aecore.Account.Tx.SpendTx
+  alias Aecore.Tx.DataTx
   alias Aecore.Wallet.Worker, as: Wallet
-  alias Aecore.Structures.Account
+  alias Aecore.Account.Account
 
   setup wallet do
     Code.require_file("test_utils.ex", "./test")

--- a/apps/aecore/test/aecore_validation_test.exs
+++ b/apps/aecore/test/aecore_validation_test.exs
@@ -9,16 +9,16 @@ defmodule AecoreValidationTest do
   alias Aecore.Persistence.Worker, as: Persistence
   alias Aecore.Chain.BlockValidation
   alias Aecore.Chain.Difficulty
-  alias Aecore.Structures.Block
-  alias Aecore.Structures.Header
-  alias Aecore.Structures.SignedTx
-  alias Aecore.Structures.DataTx
-  alias Aecore.Structures.SpendTx
-  alias Aecore.Structures.SignedTx
+  alias Aecore.Chain.Block
+  alias Aecore.Chain.Header
+  alias Aecore.Tx.SignedTx
+  alias Aecore.Tx.DataTx
+  alias Aecore.Account.Tx.SpendTx
+  alias Aecore.Tx.SignedTx
   alias Aecore.Chain.Worker, as: Chain
   alias Aecore.Miner.Worker, as: Miner
   alias Aecore.Wallet.Worker, as: Wallet
-  alias Aecore.Structures.Account
+  alias Aecore.Account.Account
 
   setup_all do
     Code.require_file("test_utils.ex", "./test")
@@ -154,7 +154,7 @@ defmodule AecoreValidationTest do
     priv_key = Wallet.get_private_key()
     {:ok, signed_tx} = SignedTx.sign_tx(tx_data, priv_key)
 
-    Aecore.Txs.Pool.Worker.add_transaction(signed_tx)
+    Aecore.Tx.Pool.Worker.add_transaction(signed_tx)
     {:ok, new_block} = Aecore.Miner.Worker.mine_sync_block(Miner.candidate())
     new_block
   end

--- a/apps/aecore/test/multiple_transactions_test.exs
+++ b/apps/aecore/test/multiple_transactions_test.exs
@@ -6,15 +6,15 @@ defmodule MultipleTransactionsTest do
   use ExUnit.Case
 
   alias Aecore.Persistence.Worker, as: Persistence
-  alias Aecore.Txs.Pool.Worker, as: Pool
+  alias Aecore.Tx.Pool.Worker, as: Pool
   alias Aecore.Miner.Worker, as: Miner
   alias Aecore.Chain.Worker, as: Chain
-  alias Aecore.Structures.SpendTx
-  alias Aecore.Structures.DataTx
-  alias Aecore.Structures.SignedTx
+  alias Aecore.Account.Tx.SpendTx
+  alias Aecore.Tx.DataTx
+  alias Aecore.Tx.SignedTx
   alias Aecore.Chain.Worker, as: Chain
   alias Aecore.Wallet.Worker, as: Wallet
-  alias Aecore.Structures.Account
+  alias Aecore.Account.Account
 
   setup do
     Code.require_file("test_utils.ex", "./test")

--- a/apps/aehttpclient/lib/client.ex
+++ b/apps/aehttpclient/lib/client.ex
@@ -3,10 +3,10 @@ defmodule Aehttpclient.Client do
   Client used for making requests to a node.
   """
 
-  alias Aecore.Structures.Block
-  alias Aecore.Structures.Header
-  alias Aecore.Structures.SignedTx
-  alias Aecore.Structures.DataTx
+  alias Aecore.Chain.Block
+  alias Aecore.Chain.Header
+  alias Aecore.Tx.SignedTx
+  alias Aecore.Tx.DataTx
   alias Aecore.Peers.Worker, as: Peers
   alias Aeutil.Serialization
   alias Aehttpserver.Web.Endpoint

--- a/apps/aehttpclient/test/aehttpclient_test.exs
+++ b/apps/aehttpclient/test/aehttpclient_test.exs
@@ -2,13 +2,13 @@ defmodule AehttpclientTest do
   use ExUnit.Case
 
   alias Aecore.Chain.Worker, as: Chain
-  alias Aecore.Txs.Pool.Worker, as: Pool
+  alias Aecore.Tx.Pool.Worker, as: Pool
   alias Aehttpclient.Client
-  alias Aecore.Structures.SignedTx
-  alias Aecore.Structures.Header
-  alias Aecore.Structures.DataTx
-  alias Aecore.Structures.SpendTx
-  alias Aecore.Structures.Account
+  alias Aecore.Tx.SignedTx
+  alias Aecore.Chain.Header
+  alias Aecore.Tx.DataTx
+  alias Aecore.Account.Tx.SpendTx
+  alias Aecore.Account.Account
   alias Aecore.Miner.Worker, as: Miner
   alias Aecore.Wallet.Worker, as: Wallet
 

--- a/apps/aehttpserver/lib/aehttpserver/web/channels/notify.ex
+++ b/apps/aehttpserver/lib/aehttpserver/web/channels/notify.ex
@@ -3,11 +3,11 @@ defmodule Aehttpserver.Web.Notify do
   Contains functionality for broadcasting new blocks/transactions via websocket.
   """
 
-  alias Aecore.Structures.SpendTx
-  alias Aecore.Structures.OracleQueryTx
+  alias Aecore.Account.Tx.SpendTx
+  alias Aecore.Oracle.Tx.OracleQueryTx
   alias Aeutil.Serialization
   alias Aehttpserver.Web.Endpoint
-  alias Aecore.Structures.Account
+  alias Aecore.Account.Account
 
   def broadcast_new_transaction_in_the_pool(tx) do
     broadcast_tx(tx, true)

--- a/apps/aehttpserver/lib/aehttpserver/web/controllers/balance_controller.ex
+++ b/apps/aehttpserver/lib/aehttpserver/web/controllers/balance_controller.ex
@@ -2,7 +2,7 @@ defmodule Aehttpserver.Web.BalanceController do
   use Aehttpserver.Web, :controller
 
   alias Aecore.Chain.Worker, as: Chain
-  alias Aecore.Structures.Account
+  alias Aecore.Account.Account
 
   def show(conn, params) do
     acc = Account.base58c_decode(params["account"])

--- a/apps/aehttpserver/lib/aehttpserver/web/controllers/block_controller.ex
+++ b/apps/aehttpserver/lib/aehttpserver/web/controllers/block_controller.ex
@@ -5,8 +5,8 @@ defmodule Aehttpserver.Web.BlockController do
   alias Aeutil.Serialization
   alias Aeutil.HTTPUtil
   alias Aecore.Chain.BlockValidation
-  alias Aecore.Structures.Block
-  alias Aecore.Structures.Header
+  alias Aecore.Chain.Block
+  alias Aecore.Chain.Header
   alias Aecore.Peers.Sync
   alias Aeutil.Serialization
 

--- a/apps/aehttpserver/lib/aehttpserver/web/controllers/info_controller.ex
+++ b/apps/aehttpserver/lib/aehttpserver/web/controllers/info_controller.ex
@@ -1,13 +1,13 @@
 defmodule Aehttpserver.Web.InfoController do
   use Aehttpserver.Web, :controller
 
-  alias Aecore.Structures.Block
-  alias Aecore.Structures.Header
+  alias Aecore.Chain.Block
+  alias Aecore.Chain.Header
   alias Aecore.Chain.Worker, as: Chain
   alias Aecore.Chain.BlockValidation
   alias Aecore.Wallet.Worker, as: Wallet
   alias Aecore.Peers.Worker, as: Peers
-  alias Aecore.Structures.Account
+  alias Aecore.Account.Account
   alias Plug.Conn
 
   require Logger

--- a/apps/aehttpserver/lib/aehttpserver/web/controllers/new_tx_controller.ex
+++ b/apps/aehttpserver/lib/aehttpserver/web/controllers/new_tx_controller.ex
@@ -3,7 +3,7 @@ defmodule Aehttpserver.Web.NewTxController do
 
   alias Aeutil.Serialization
   alias Aeutil.HTTPUtil
-  alias Aecore.Txs.Pool.Worker, as: Pool
+  alias Aecore.Tx.Pool.Worker, as: Pool
 
   def new_tx(conn, _params) do
     deserialized_tx = Serialization.tx(conn.body_params, :deserialize)

--- a/apps/aehttpserver/lib/aehttpserver/web/controllers/oracle_controller.ex
+++ b/apps/aehttpserver/lib/aehttpserver/web/controllers/oracle_controller.ex
@@ -2,7 +2,7 @@ defmodule Aehttpserver.Web.OracleController do
   use Aehttpserver.Web, :controller
 
   alias Aecore.Oracle.Oracle
-  alias Aecore.Structures.Account
+  alias Aecore.Account.Account
   alias Aecore.Chain.Worker, as: Chain
   alias Aeutil.Serialization
   alias Aeutil.Bits

--- a/apps/aehttpserver/lib/aehttpserver/web/controllers/tx_controller.ex
+++ b/apps/aehttpserver/lib/aehttpserver/web/controllers/tx_controller.ex
@@ -1,9 +1,9 @@
 defmodule Aehttpserver.Web.TxController do
   use Aehttpserver.Web, :controller
 
-  alias Aecore.Txs.Pool.Worker, as: Pool
+  alias Aecore.Tx.Pool.Worker, as: Pool
   alias Aeutil.Serialization
-  alias Aecore.Structures.Account
+  alias Aecore.Account.Account
 
   def show(conn, params) do
     account_bin = Account.base58c_decode(params["account"])

--- a/apps/aehttpserver/lib/aehttpserver/web/controllers/tx_pool_controller.ex
+++ b/apps/aehttpserver/lib/aehttpserver/web/controllers/tx_pool_controller.ex
@@ -1,9 +1,9 @@
 defmodule Aehttpserver.Web.TxPoolController do
   use Aehttpserver.Web, :controller
 
-  alias Aecore.Txs.Pool.Worker, as: Pool
+  alias Aecore.Tx.Pool.Worker, as: Pool
   alias Aeutil.Serialization
-  alias Aecore.Structures.Account
+  alias Aecore.Account.Account
 
   def show(conn, params) do
     pool_txs = Map.values(Pool.get_pool())

--- a/apps/aeutil/lib/serialization.ex
+++ b/apps/aeutil/lib/serialization.ex
@@ -3,16 +3,16 @@ defmodule Aeutil.Serialization do
   Utility module for serialization
   """
 
-  alias Aecore.Structures.Block
-  alias Aecore.Structures.Header
-  alias Aecore.Structures.SpendTx
-  alias Aecore.Structures.OracleQueryTx
-  alias Aecore.Structures.DataTx
-  alias Aecore.Structures.SignedTx
-  alias Aecore.Structures.Chainstate
+  alias Aecore.Chain.Block
+  alias Aecore.Chain.Header
+  alias Aecore.Account.Tx.SpendTx
+  alias Aecore.Oracle.Tx.OracleQueryTx
+  alias Aecore.Tx.DataTx
+  alias Aecore.Tx.SignedTx
+  alias Aecore.Chain.Chainstate
   alias Aeutil.Parser
-  alias Aecore.Structures.Account
-  alias Aecore.Structures.SpendTx
+  alias Aecore.Account.Account
+  alias Aecore.Account.Tx.SpendTx
 
   @type transaction_types :: SpendTx.t() | DataTx.t()
 

--- a/apps/aeutil/test/aeutil_serialization_test.exs
+++ b/apps/aeutil/test/aeutil_serialization_test.exs
@@ -2,11 +2,11 @@ defmodule AeutilSerializationTest do
   use ExUnit.Case
 
   alias Aeutil.Serialization
-  alias Aecore.Structures.DataTx
-  alias Aecore.Structures.SignedTx
-  alias Aecore.Structures.SpendTx
-  alias Aecore.Structures.Block
-  alias Aecore.Structures.Header
+  alias Aecore.Tx.DataTx
+  alias Aecore.Tx.SignedTx
+  alias Aecore.Account.Tx.SpendTx
+  alias Aecore.Chain.Block
+  alias Aecore.Chain.Header
 
   @tag :serialization
   test "serialize a block" do
@@ -76,7 +76,7 @@ defmodule AeutilSerializationTest do
               "amount" => 100,
               "version" => 1
             },
-            "type" => "Elixir.Aecore.Structures.SpendTx"
+            "type" => "Elixir.Aecore.Account.Tx.SpendTx"
           },
           "signature" => "AQID"
         }


### PR DESCRIPTION
Only `Aecore.Chain.Account` is in a little bit miserable place. If somebody has better idea please tell me

This closes #321

commands to reproduce my results:
```
find . -type f -name "*.ex*" -exec sed -i.bak "s/Aecore.Structures.Block/Aecore.Chain.Block/g" {} \;
find . -type f -name "*.ex*" -exec sed -i.bak "s/Aecore.Structures.Header/Aecore.Chain.Header/g" {} \;
find . -type f -name "*.ex*" -exec sed -i.bak "s/Aecore.Structures.Account/Aecore.Chain.Account/g" {} \;
find . -type f -name "*.ex*" -exec sed -i.bak "s/Aecore.Structures.DataTx/Aecore.Tx.DataTx/g" {} \;
find . -type f -name "*.ex*" -exec sed -i.bak "s/Aecore.Structures.SignedTx/Aecore.Tx.SignedTx/g" {} \;
find . -type f -name "*.ex*" -exec sed -i.bak "s/Aecore.Structures.SpendTx/Aecore.Tx.Type.SpendTx/g" {} \;
find . -type f -name "*.ex*" -exec sed -i.bak "s/Aecore.Structures.OracleRegistrationTx/Aecore.Tx.Type.OracleRegistrationTx/g" {} \;
find . -type f -name "*.ex*" -exec sed -i.bak "s/Aecore.Structures.OracleQueryTx/Aecore.Tx.Type.OracleQueryTx/g" {} \;
find . -type f -name "*.ex*" -exec sed -i.bak "s/Aecore.Structures.OracleResponseTx/Aecore.Tx.Type.OracleResponseTx/g" {} \;
find . -type f -name "*.ex*" -exec sed -i.bak "s/Aecore.Structures.OracleExtendTx/Aecore.Tx.Type.OracleExtendTx/g" {} \;
find . -type f -name "*.ex*" -exec sed -i.bak "s/Aecore.Txs/Aecore.Tx/g" {} \;
find . -type f -name "*.ex*" -exec sed -i.bak "s/Aecore.Chain.Account/Aecore.Account.Account/g" {} \;
find . -type f -name "*.ex*" -exec sed -i.bak "s/Aecore.Tx.Type.SpendTx/Aecore.Account.Tx.SpendTx/g" {} \;
find . -type f -name "*.ex*" -exec sed -i.bak "s/Aecore.Tx.Type.Oracle/Aecore.Oracle.Tx.Oracle/g" {} \;
find . -type f -name "*.ex*" -exec sed -i.bak "s/Aecore.Structures.Transaction/Aecore.Tx.Transaction/g" {} \;
find . -type f -name "*.ex*" -exec sed -i.bak "s/Aecore.Structures.AccountStateTree/Aecore.Account.AccountStateTree/g" {} \;
find . -type f -name "*.ex*" -exec sed -i.bak "s/Aecore.Structures.Chainstate/Aecore.Chain.Chainstate/g" {} \;
find -name "*.bak" -delete
```