### PR TITLE
[GH-#307] Add multi node sync testcase

### DIFF
--- a/apps/aecore/test/aecore_multi_node_sync_test.exs
+++ b/apps/aecore/test/aecore_multi_node_sync_test.exs
@@ -1,7 +1,6 @@
 defmodule MultiNodeSyncTest do
   use ExUnit.Case
 
-  alias Aeutil.Serialization
   alias Aecore.Peers.Worker, as: Peers
   alias Aecore.Miner.Worker, as: Miner
   alias Aecore.Chain.Worker, as: Chain
@@ -18,7 +17,9 @@ defmodule MultiNodeSyncTest do
     str = "defmodule MultiNodeSyncTest do
       use ExUnit.Case
 
-      alias Aeutil.Serialization
+      alias Aecore.Account.Account
+      alias Aecore.Tx.Pool.Worker, as: Pool
+      alias Aecore.Wallet.Worker, as: Wallet
       alias Aecore.Peers.Worker, as: Peers
       alias Aecore.Miner.Worker, as: Miner
       alias Aecore.Chain.Worker, as: Chain
@@ -34,8 +35,9 @@ defmodule MultiNodeSyncTest do
       test \"run_sync\" do
         Peers.add_peer(\"localhost:4000\")
         :timer.sleep(5000)
+        {:ok, tx} = Account.spend(Wallet.get_public_key(\"M/0\"), 100, 10)
+        Pool.add_transaction(tx)
         Miner.mine_sync_block_to_chain()
-        :timer.sleep(5000)
         path = \"block.txt\"
         binary = :erlang.term_to_binary(Chain.top_block())
         File.write(path, binary)

--- a/apps/aecore/test/aecore_multi_node_sync_test.exs
+++ b/apps/aecore/test/aecore_multi_node_sync_test.exs
@@ -1,15 +1,61 @@
 defmodule MultiNodeSyncTest do
   use ExUnit.Case
+
+  alias Aecore.Peers.Worker, as: Peers
+  alias Aecore.Miner.Worker, as: Miner
+  alias Aecore.Chain.Worker, as: Chain
   @tag timeout: 180000
 
+  setup do
+    Peers.start_link([])
+    Miner.start_link([])
+    Chain.start_link([])
+    []
+  end
+
   test "run second node" do
+
+    str = "defmodule MultiNodeSyncTest do
+      use ExUnit.Case
+
+      alias Aecore.Peers.Worker, as: Peers
+      alias Aecore.Miner.Worker, as: Miner
+      alias Aecore.Chain.Worker, as: Chain
+      @tag timeout: 180000
+
+      setup do
+        Peers.start_link([])
+        Miner.start_link([])
+        Chain.start_link([])
+        []
+      end
+
+      test \"run_sync\" do
+        Peers.add_peer(\"localhost:4000\")
+        :timer.sleep(5000)
+        Miner.mine_sync_block_to_chain()
+        :timer.sleep(5000)
+        IO.puts \"Second node:\"
+        IO.inspect Chain.top_block()
+      end
+    end"
     System.cmd("cp", ["-R", "../../../elixir-node", "../../../elixir-node2"])
     System.cmd "rm", ["-rf", "../../../elixir-node2/apps/aecore/test/"]
+    System.cmd "mkdir", ["../../../elixir-node2/apps/aecore/test/"]
+    System.cmd("cp", ["../../../elixir-node/apps/aecore/test/test_helper.exs", "../../../elixir-node2/apps/aecore/test/test_helper.exs"])
+    System.cmd("cp", ["../../../elixir-node/apps/aecore/test/test_utils.ex", "../../../elixir-node2/apps/aecore/test/test_utils.ex"])
+    {:ok, file} = File.open "../../../elixir-node2/apps/aecore/test/multi_node_sync_test.exs", [:write]
+    IO.write(file, str)
     System.cmd "rm", ["../../../elixir-node2/apps/aehttpclient/test/aehttpclient_test.exs"]
-    System.cmd "sed", ["-i", "s/4000/4001/", "../../../elixir-node2/apps/aehttpserver/config/dev.exs"]
-    System.cmd "sed", ["-i", "s/4000/4001/", "../../../elixir-node2/apps/aehttpserver/config/test.exs"]
+    System.cmd "sed", ["-i", "s/4000/4002/", "../../../elixir-node2/apps/aehttpserver/config/dev.exs"]
+    System.cmd "sed", ["-i", "s/4000/4002/", "../../../elixir-node2/apps/aehttpserver/config/test.exs"]
 
+    Miner.mine_sync_block_to_chain
     System.cmd "mix", ["test"], cd: "../../../elixir-node2", into: IO.stream(:stdio, :line)
+    IO.puts "First node:"
+    IO.inspect Chain.top_block()
     System.cmd "rm", ["-rf", "../../../elixir-node2"]
   end
+
+
 end

--- a/apps/aecore/test/aecore_multi_node_sync_test.exs
+++ b/apps/aecore/test/aecore_multi_node_sync_test.exs
@@ -1,0 +1,15 @@
+defmodule MultiNodeSyncTest do
+  use ExUnit.Case
+  @tag timeout: 180000
+
+  test "run second node" do
+    System.cmd("cp", ["-R", "../../../elixir-node", "../../../elixir-node2"])
+    System.cmd "rm", ["-rf", "../../../elixir-node2/apps/aecore/test/"]
+    System.cmd "rm", ["../../../elixir-node2/apps/aehttpclient/test/aehttpclient_test.exs"]
+    System.cmd "sed", ["-i", "s/4000/4001/", "../../../elixir-node2/apps/aehttpserver/config/dev.exs"]
+    System.cmd "sed", ["-i", "s/4000/4001/", "../../../elixir-node2/apps/aehttpserver/config/test.exs"]
+
+    System.cmd "mix", ["test"], cd: "../../../elixir-node2", into: IO.stream(:stdio, :line)
+    System.cmd "rm", ["-rf", "../../../elixir-node2"]
+  end
+end

--- a/apps/aecore/test/aecore_multi_node_sync_test.exs
+++ b/apps/aecore/test/aecore_multi_node_sync_test.exs
@@ -5,7 +5,7 @@ defmodule MultiNodeSyncTest do
   alias Aecore.Peers.Worker, as: Peers
   alias Aecore.Miner.Worker, as: Miner
   alias Aecore.Chain.Worker, as: Chain
-  @tag timeout: 180000
+  @tag timeout: 180_000
 
   setup do
     Peers.start_link([])
@@ -15,7 +15,6 @@ defmodule MultiNodeSyncTest do
   end
 
   test "run second node" do
-
     str = "defmodule MultiNodeSyncTest do
       use ExUnit.Case
 
@@ -43,22 +42,43 @@ defmodule MultiNodeSyncTest do
       end
     end"
     System.cmd("cp", ["-R", "../../../elixir-node", "../../../elixir-node2"])
-    System.cmd "rm", ["-rf", "../../../elixir-node2/apps/aecore/test/"]
-    System.cmd "mkdir", ["../../../elixir-node2/apps/aecore/test/"]
-    System.cmd("cp", ["../../../elixir-node/apps/aecore/test/test_helper.exs", "../../../elixir-node2/apps/aecore/test/test_helper.exs"])
-    System.cmd("cp", ["../../../elixir-node/apps/aecore/test/test_utils.ex", "../../../elixir-node2/apps/aecore/test/test_utils.ex"])
-    {:ok, file} = File.open "../../../elixir-node2/apps/aecore/test/multi_node_sync_test.exs", [:write]
-    IO.write(file, str)
-    System.cmd "rm", ["../../../elixir-node2/apps/aehttpclient/test/aehttpclient_test.exs"]
-    System.cmd "sed", ["-i", "s/4000/4002/", "../../../elixir-node2/apps/aehttpserver/config/dev.exs"]
-    System.cmd "sed", ["-i", "s/4000/4002/", "../../../elixir-node2/apps/aehttpserver/config/test.exs"]
+    System.cmd("rm", ["-rf", "../../../elixir-node2/apps/aecore/test/"])
+    System.cmd("mkdir", ["../../../elixir-node2/apps/aecore/test/"])
 
-    Miner.mine_sync_block_to_chain
-    System.cmd "mix", ["test"], cd: "../../../elixir-node2", into: IO.stream(:stdio, :line)
-    {:ok, top_block_binary} = File.read "../../../elixir-node2/apps/aecore/block.txt"
+    System.cmd("cp", [
+      "../../../elixir-node/apps/aecore/test/test_helper.exs",
+      "../../../elixir-node2/apps/aecore/test/test_helper.exs"
+    ])
+
+    System.cmd("cp", [
+      "../../../elixir-node/apps/aecore/test/test_utils.ex",
+      "../../../elixir-node2/apps/aecore/test/test_utils.ex"
+    ])
+
+    {:ok, file} =
+      File.open("../../../elixir-node2/apps/aecore/test/multi_node_sync_test.exs", [:write])
+
+    IO.write(file, str)
+    System.cmd("rm", ["../../../elixir-node2/apps/aehttpclient/test/aehttpclient_test.exs"])
+
+    System.cmd("sed", [
+      "-i",
+      "s/4000/4002/",
+      "../../../elixir-node2/apps/aehttpserver/config/dev.exs"
+    ])
+
+    System.cmd("sed", [
+      "-i",
+      "s/4000/4002/",
+      "../../../elixir-node2/apps/aehttpserver/config/test.exs"
+    ])
+
+    Miner.mine_sync_block_to_chain()
+    System.cmd("mix", ["test"], cd: "../../../elixir-node2", into: IO.stream(:stdio, :line))
+    {:ok, top_block_binary} = File.read("../../../elixir-node2/apps/aecore/block.txt")
     top_block = :erlang.binary_to_term(top_block_binary)
 
     assert Chain.top_block() == top_block
-    System.cmd "rm", ["-rf", "../../../elixir-node2"]
+    System.cmd("rm", ["-rf", "../../../elixir-node2"])
   end
 end

--- a/apps/aecore/test/aecore_multi_node_sync_test.exs
+++ b/apps/aecore/test/aecore_multi_node_sync_test.exs
@@ -34,6 +34,7 @@ defmodule MultiNodeSyncTest do
 
       test \"run_sync\" do
         Peers.add_peer(\"localhost:4000\")
+        Miner.mine_sync_block_to_chain()
         :timer.sleep(5000)
         {:ok, tx} = Account.spend(Wallet.get_public_key(\"M/0\"), 100, 10)
         Pool.add_transaction(tx)


### PR DESCRIPTION
Adding multi node sync test, it works in the following way: 
1) Copies the whole elixir node to the separate folder, and deletes all the unnecessary tests.
2) Creates a test file for the second node.
3) Changes the port of the second node.
4) Mines the first coinbase_tx and runs the mix test for the second node.
5) In the second node test it mines spend_tx and coinbase_tx in order to fill the chain with some data.
5) Writes the result of the test of the second node (Chain.top_block - result) to the file.
6) Compare the Chain.top_block of the first node with the Chain.top_block of the second node,
7) If they are similar, then nodes are synchronized correctly and test is passed.

resolves #307 