### PR TITLE
[GH-502] Changed ChannelStateOffChain signing_form to RLP

### DIFF
--- a/apps/aecore/lib/aecore/channel/channel_state_off_chain.ex
+++ b/apps/aecore/lib/aecore/channel/channel_state_off_chain.ex
@@ -9,6 +9,10 @@ defmodule Aecore.Channel.ChannelStateOffChain do
   alias Aewallet.Signing
   alias Aeutil.Serialization
 
+  @signing_tag 101
+
+  @version 1
+
   @type t :: %ChannelStateOffChain{
           channel_id: binary(),
           sequence: non_neg_integer(),
@@ -296,13 +300,15 @@ defmodule Aecore.Channel.ChannelStateOffChain do
   end
 
   defp signing_form(%ChannelStateOffChain{} = state) do
-    map = %{
-      channel_id: state.channel_id,
-      initiator_amount: state.initiator_amount,
-      responder_amount: state.responder_amount,
-      sequence: state.sequence
-    }
+    list_form = [
+      @signing_tag,
+      @version,
+      state.channel_id,
+      state.initiator_amount,
+      state.responder_amount,
+      state.sequence
+    ]
 
-    Serialization.pack_binary(map)
+    ExRLP.encode(list_form)
   end
 end

--- a/apps/aeutil/lib/serialization.ex
+++ b/apps/aeutil/lib/serialization.ex
@@ -733,6 +733,9 @@ defmodule Aeutil.Serialization do
   def type_to_tag(ChannelSlashTx), do: {:ok, 45}
 
   def type_to_tag(Block), do: {:ok, Application.get_env(:aecore, :rlp_tags)[:block]}
+
+  # 101 is reserved for ChannelStateOffChain signing
+
   def type_to_tag(type), do: {:error, "#{__MODULE__} : Unknown TX Type: #{type}"}
 
   @spec tag_to_type(non_neg_integer()) :: atom() | {:error, String.t()}
@@ -759,6 +762,7 @@ defmodule Aeutil.Serialization do
   def tag_to_type(21), do: OracleQuery
   def tag_to_type(11), do: SignedTx
   def tag_to_type(100), do: Block
+  # 101 is reserved for ChannelStateOffChain signing
   def tag_to_type(tag), do: {:error, "#{__MODULE__} : Unknown TX Tag: #{inspect(tag)}"}
 
   @spec get_version(atom()) :: non_neg_integer() | {:error, String.t()}


### PR DESCRIPTION
As in title. The new singing_form isn't as in epoch, but the epoch signing_form is very complicated. It looks like they are creating a merkle tree and adding this tree to their "trees" structure and then finally signing the hash of this structure.