### PR TITLE
[GH-521] More Travis chaching

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,3 +28,6 @@ cache:
     - $HOME/.cargo
     - deps
     - _build
+    - aevm_external
+    - apps/aecore/src/cuckoo/c_src
+    - apps/aecore/priv/cuckoo

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ env:
 
 before_install:
   - wget -O libsodium-src.tar.gz https://github.com/jedisct1/libsodium/releases/download/1.0.16/libsodium-1.0.16.tar.gz
-  - mkdir libsodium-src && tar -zxf libsodium-src.tar.gz -C libsodium-src --strip-components=1
+  - "[ -d libsodium-src ] || mkdir libsodium-src && tar -zxf libsodium-src.tar.gz -C libsodium-src --strip-components=1"
   - cd libsodium-src && ./configure --prefix=$HOME/.libsodium && make -j$(nproc) && make install && cd ..
   - curl https://sh.rustup.rs -sSf | sh -s -- -y
   - source $HOME/.cargo/env
@@ -31,3 +31,4 @@ cache:
     - aevm_external
     - apps/aecore/src/cuckoo/c_src
     - apps/aecore/priv/cuckoo
+    - libsodium-src


### PR DESCRIPTION
This PR adds few folders to Travis cache and decreases build time from about 8min30 to about 5min30.
Following was added to cache:
- libsodium build, but not configure
- cuckoo
- aevm tests files

Cache size increased from 323.83MB to 499.62MB

To speed up tests further we should create some mock mining for tests. (Running cuckoo is the time consuming part of tests) Aside from that installing rust takes 25sec, libsodium/configure takes 15sec and initializing build with downloading cache takes about 1min.

This closes #521 