### PR TITLE
[GH-534] Proper blockchain cleaning

### DIFF
--- a/apps/aecore/lib/aecore.ex
+++ b/apps/aecore/lib/aecore.ex
@@ -5,8 +5,6 @@ defmodule Aecore do
 
   use Application
 
-  import Supervisor.Spec
-
   def start(_type, _args) do
     children = [
       Aecore.Persistence.Worker.Supervisor,
@@ -14,8 +12,7 @@ defmodule Aecore do
       Aecore.Miner.Worker.Supervisor,
       Aecore.Tx.Pool.Worker.Supervisor,
       Aecore.Peers.Worker.Supervisor,
-      Aecore.Channel.Worker.Supervisor,
-      supervisor(Exexec, [], function: :start)
+      Aecore.Channel.Worker.Supervisor
     ]
 
     Supervisor.start_link(children, strategy: :one_for_one)

--- a/apps/aecore/lib/aecore.ex
+++ b/apps/aecore/lib/aecore.ex
@@ -15,6 +15,6 @@ defmodule Aecore do
       Aecore.Channel.Worker.Supervisor
     ]
 
-    Supervisor.start_link(children, strategy: :one_for_one)
+    Supervisor.start_link(children, strategy: :one_for_one, name: __MODULE__)
   end
 end

--- a/apps/aecore/lib/aecore/persistence/worker.ex
+++ b/apps/aecore/lib/aecore/persistence/worker.ex
@@ -188,7 +188,11 @@ defmodule Aecore.Persistence.Worker do
        "total_difficulty_family" => total_difficulty_family,
        "patricia_channels_family" => patricia_channels_family
      } = families_map} =
-      Rox.open(persistence_path(), [create_if_missing: true, auto_create_column_families: true], all_families())
+      Rox.open(
+        persistence_path(),
+        [create_if_missing: true, auto_create_column_families: true],
+        all_families()
+      )
 
     {:ok,
      %{
@@ -366,6 +370,7 @@ defmodule Aecore.Persistence.Worker do
         end)
       end)
       |> Batch.write(db)
+
     {:reply, status, state}
   end
 

--- a/apps/aecore/lib/aecore/persistence/worker.ex
+++ b/apps/aecore/lib/aecore/persistence/worker.ex
@@ -374,22 +374,6 @@ defmodule Aecore.Persistence.Worker do
     {:reply, status, state}
   end
 
-  def handle_call(:delete_all_blocks, _from, %{blocks_family: blocks_family} = state) do
-    blocks_family
-    |> Rox.stream()
-    |> Enum.each(fn {key, _} -> Rox.delete(blocks_family, key) end)
-
-    {:reply, :ok, state}
-  end
-
-  def handle_call(:delete_chainstate, _from, %{chain_state_family: chain_state_family} = state) do
-    chain_state_family
-    |> Rox.stream()
-    |> Enum.each(fn {key, _} -> Rox.delete(chain_state_family, key) end)
-
-    {:reply, :ok, state}
-  end
-
   def handle_call(
         {:get_all_chainstates, block_hash},
         _from,

--- a/apps/aecore/lib/aecore/persistence/worker.ex
+++ b/apps/aecore/lib/aecore/persistence/worker.ex
@@ -152,7 +152,7 @@ defmodule Aecore.Persistence.Worker do
 
   ## Server side
 
-  defp all_families() do
+  defp all_families do
     [
       "blocks_family",
       "latest_block_info_family",

--- a/apps/aecore/lib/aecore/persistence/worker.ex
+++ b/apps/aecore/lib/aecore/persistence/worker.ex
@@ -129,12 +129,9 @@ defmodule Aecore.Persistence.Worker do
     GenServer.call(__MODULE__, :get_total_difficulty)
   end
 
-  def delete_all_blocks do
-    GenServer.call(__MODULE__, :delete_all_blocks)
-  end
-
-  def delete_chainstate do
-    GenServer.call(__MODULE__, :delete_chainstate)
+  @spec delete_all() :: :ok | {:error, any()}
+  def delete_all do
+    GenServer.call(__MODULE__, :delete_all)
   end
 
   @doc """
@@ -155,6 +152,23 @@ defmodule Aecore.Persistence.Worker do
 
   ## Server side
 
+  defp all_families() do
+    [
+      "blocks_family",
+      "latest_block_info_family",
+      "chain_state_family",
+      "blocks_info_family",
+      "patricia_proof_family",
+      "patricia_oracles_family",
+      "patricia_oracles_cache_family",
+      "patricia_txs_family",
+      "patricia_account_family",
+      "patricia_naming_family",
+      "total_difficulty_family",
+      "patricia_channels_family"
+    ]
+  end
+
   def init(_) do
     ## We are ensuring that families for the blocks and chain state
     ## are created. More about them -
@@ -173,25 +187,13 @@ defmodule Aecore.Persistence.Worker do
        "patricia_naming_family" => patricia_naming_family,
        "total_difficulty_family" => total_difficulty_family,
        "patricia_channels_family" => patricia_channels_family
-     }} =
-      Rox.open(persistence_path(), [create_if_missing: true, auto_create_column_families: true], [
-        "blocks_family",
-        "latest_block_info_family",
-        "chain_state_family",
-        "blocks_info_family",
-        "patricia_proof_family",
-        "patricia_oracles_family",
-        "patricia_oracles_cache_family",
-        "patricia_txs_family",
-        "patricia_account_family",
-        "patricia_naming_family",
-        "total_difficulty_family",
-        "patricia_channels_family"
-      ])
+     } = families_map} =
+      Rox.open(persistence_path(), [create_if_missing: true, auto_create_column_families: true], all_families())
 
     {:ok,
      %{
        db: db,
+       families_map: families_map,
        blocks_family: blocks_family,
        latest_block_info_family: latest_block_info_family,
        chain_state_family: chain_state_family,
@@ -350,6 +352,21 @@ defmodule Aecore.Persistence.Worker do
       end
 
     {:reply, total_diff, state}
+  end
+
+  def handle_call(:delete_all, _from, %{db: db, families_map: families_map} = state) do
+    status =
+      families_map
+      |> Map.values()
+      |> Enum.reduce(Batch.new(), fn family, batch_acc ->
+        family
+        |> Rox.stream()
+        |> Enum.reduce(batch_acc, fn {key, _}, batch_acc ->
+          Batch.delete(batch_acc, family, key)
+        end)
+      end)
+      |> Batch.write(db)
+    {:reply, status, state}
   end
 
   def handle_call(:delete_all_blocks, _from, %{blocks_family: blocks_family} = state) do

--- a/apps/aecore/lib/aecore/persistence/worker.ex
+++ b/apps/aecore/lib/aecore/persistence/worker.ex
@@ -306,7 +306,7 @@ defmodule Aecore.Persistence.Worker do
         blocks_family
         |> Rox.stream()
         |> Enum.reduce([], fn {_hash, %{header: %{height: height}}} = record, acc ->
-          if threshold < height do
+          if threshold <= height do
             [record | acc]
           else
             acc

--- a/apps/aecore/mix.exs
+++ b/apps/aecore/mix.exs
@@ -36,7 +36,7 @@ defmodule Aecore.Mixfile do
   def application do
     # Specify extra applications you'll use from Erlang/Elixir
     [
-      extra_applications: [:gproc, :logger, :rox, :exconstructor, :ranch, :jobs],
+      extra_applications: [:erlexec, :gproc, :logger, :rox, :exconstructor, :ranch, :jobs],
       mod: {Aecore, []}
     ]
   end
@@ -62,7 +62,7 @@ defmodule Aecore.Mixfile do
       {:excoveralls, "~> 0.8.1", only: :test},
       {:exexec, "~> 0.1"},
       {:jobs, "~> 0.7.1"},
-      {:gproc, "~> 0.6.1"}
+      {:gproc, "~> 0.6.1"},
     ]
   end
 end

--- a/apps/aecore/mix.exs
+++ b/apps/aecore/mix.exs
@@ -62,7 +62,7 @@ defmodule Aecore.Mixfile do
       {:excoveralls, "~> 0.8.1", only: :test},
       {:exexec, "~> 0.1"},
       {:jobs, "~> 0.7.1"},
-      {:gproc, "~> 0.6.1"},
+      {:gproc, "~> 0.6.1"}
     ]
   end
 end

--- a/apps/aecore/test/aecore_chain_state_test.exs
+++ b/apps/aecore/test/aecore_chain_state_test.exs
@@ -7,15 +7,14 @@ defmodule AecoreChainstateTest do
 
   alias Aecore.Account.Account
   alias Aecore.Chain.Worker, as: Chain
-  alias Aecore.Persistence.Worker, as: Persistence
   alias Aecore.Account.AccountStateTree
   alias Aecore.Chain.Chainstate
 
   setup do
+    Code.require_file("test_utils.ex", "./test")
+    TestUtils.clean_blockchain()
     on_exit(fn ->
-      Persistence.delete_all()
-      Chain.clear_state()
-      :ok
+      TestUtils.clean_blockchain()
     end)
   end
 

--- a/apps/aecore/test/aecore_chain_state_test.exs
+++ b/apps/aecore/test/aecore_chain_state_test.exs
@@ -13,7 +13,7 @@ defmodule AecoreChainstateTest do
 
   setup do
     on_exit(fn ->
-      Persistence.delete_all_blocks()
+      Persistence.delete_all()
       Chain.clear_state()
       :ok
     end)

--- a/apps/aecore/test/aecore_chain_state_test.exs
+++ b/apps/aecore/test/aecore_chain_state_test.exs
@@ -13,6 +13,7 @@ defmodule AecoreChainstateTest do
   setup do
     Code.require_file("test_utils.ex", "./test")
     TestUtils.clean_blockchain()
+
     on_exit(fn ->
       TestUtils.clean_blockchain()
     end)

--- a/apps/aecore/test/aecore_chain_test.exs
+++ b/apps/aecore/test/aecore_chain_test.exs
@@ -16,11 +16,11 @@ defmodule AecoreChainTest do
   alias Aecore.Governance.GovernanceConstants
 
   setup do
-    # Persistence.delete_all_blocks()
+    # Persistence.delete_all()
     Chain.start_link([])
 
     on_exit(fn ->
-      Persistence.delete_all_blocks()
+      Persistence.delete_all()
       Chain.clear_state()
       :ok
     end)

--- a/apps/aecore/test/aecore_chain_test.exs
+++ b/apps/aecore/test/aecore_chain_test.exs
@@ -5,7 +5,6 @@ defmodule AecoreChainTest do
 
   use ExUnit.Case
 
-  alias Aecore.Persistence.Worker, as: Persistence
   alias Aecore.Chain.Chainstate
   alias Aecore.Chain.Block
   alias Aecore.Chain.Header
@@ -16,16 +15,11 @@ defmodule AecoreChainTest do
   alias Aecore.Governance.GovernanceConstants
 
   setup do
-    # Persistence.delete_all()
-    Chain.start_link([])
-
+    Code.require_file("test_utils.ex", "./test")
+    TestUtils.clean_blockchain()
     on_exit(fn ->
-      Persistence.delete_all()
-      Chain.clear_state()
-      :ok
+      TestUtils.clean_blockchain()
     end)
-
-    []
   end
 
   @tag timeout: 100_000

--- a/apps/aecore/test/aecore_chain_test.exs
+++ b/apps/aecore/test/aecore_chain_test.exs
@@ -17,6 +17,7 @@ defmodule AecoreChainTest do
   setup do
     Code.require_file("test_utils.ex", "./test")
     TestUtils.clean_blockchain()
+
     on_exit(fn ->
       TestUtils.clean_blockchain()
     end)

--- a/apps/aecore/test/aecore_channels_test.exs
+++ b/apps/aecore/test/aecore_channels_test.exs
@@ -30,7 +30,9 @@ defmodule AecoreChannelTest do
     on_exit(fn ->
       TestUtils.clean_blockchain()
     end)
+  end
 
+  setup do
     %{public: pk1, secret: prk1} = :enacl.sign_keypair()
     %{public: pk2, secret: prk2} = :enacl.sign_keypair()
 

--- a/apps/aecore/test/aecore_get_txs_for_address.exs
+++ b/apps/aecore/test/aecore_get_txs_for_address.exs
@@ -12,7 +12,7 @@ defmodule GetTxsForAddressTest do
 
   setup do
     on_exit(fn ->
-      Persistence.delete_all_blocks()
+      Persistence.delete_all()
       Chain.clear_state()
       :ok
     end)

--- a/apps/aecore/test/aecore_get_txs_for_address.exs
+++ b/apps/aecore/test/aecore_get_txs_for_address.exs
@@ -11,13 +11,11 @@ defmodule GetTxsForAddressTest do
   alias Aeutil.Serialization
 
   setup do
+    Code.require_file("test_utils.ex", "./test")
+    TestUtils.clean_blockchain()
     on_exit(fn ->
-      Persistence.delete_all()
-      Chain.clear_state()
-      :ok
+      TestUtils.clean_blockchain()
     end)
-
-    []
   end
 
   @tag timeout: 20_000

--- a/apps/aecore/test/aecore_get_txs_for_address.exs
+++ b/apps/aecore/test/aecore_get_txs_for_address.exs
@@ -13,6 +13,7 @@ defmodule GetTxsForAddressTest do
   setup do
     Code.require_file("test_utils.ex", "./test")
     TestUtils.clean_blockchain()
+
     on_exit(fn ->
       TestUtils.clean_blockchain()
     end)

--- a/apps/aecore/test/aecore_miner_test.exs
+++ b/apps/aecore/test/aecore_miner_test.exs
@@ -8,6 +8,7 @@ defmodule MinerTest do
   setup do
     Code.require_file("test_utils.ex", "./test")
     TestUtils.clean_blockchain()
+
     on_exit(fn ->
       TestUtils.clean_blockchain()
     end)

--- a/apps/aecore/test/aecore_miner_test.exs
+++ b/apps/aecore/test/aecore_miner_test.exs
@@ -8,7 +8,7 @@ defmodule MinerTest do
 
   setup do
     on_exit(fn ->
-      Persistence.delete_all_blocks()
+      Persistence.delete_all()
       :ok
     end)
   end

--- a/apps/aecore/test/aecore_miner_test.exs
+++ b/apps/aecore/test/aecore_miner_test.exs
@@ -1,15 +1,15 @@
 defmodule MinerTest do
   use ExUnit.Case
 
-  alias Aecore.Persistence.Worker, as: Persistence
   alias Aecore.Chain.Worker, as: Chain
   alias Aecore.Miner.Worker, as: Miner
   alias Aecore.Keys
 
   setup do
+    Code.require_file("test_utils.ex", "./test")
+    TestUtils.clean_blockchain()
     on_exit(fn ->
-      Persistence.delete_all()
-      :ok
+      TestUtils.clean_blockchain()
     end)
   end
 

--- a/apps/aecore/test/aecore_naming_test.exs
+++ b/apps/aecore/test/aecore_naming_test.exs
@@ -5,7 +5,6 @@ defmodule AecoreNamingTest do
 
   use ExUnit.Case
 
-  alias Aecore.Persistence.Worker, as: Persistence
   alias Aecore.Chain.Worker, as: Chain
   alias Aecore.Miner.Worker, as: Miner
   alias Aecore.Tx.Pool.Worker, as: Pool
@@ -16,17 +15,14 @@ defmodule AecoreNamingTest do
   alias Aeutil.PatriciaMerkleTree
 
   setup do
-    Persistence.start_link([])
-    Miner.start_link([])
-    Chain.clear_state()
-    Pool.get_and_empty_pool()
-
+    Code.require_file("test_utils.ex", "./test")
+    TestUtils.clean_blockchain()
     on_exit(fn ->
-      Persistence.delete_all()
-      Chain.clear_state()
-      :ok
+      TestUtils.clean_blockchain()
     end)
+  end
 
+  setup do
     %{public: a_pub_key, secret: a_priv_key} = :enacl.sign_keypair()
     %{public: b_pub_key, secret: b_priv_key} = :enacl.sign_keypair()
 

--- a/apps/aecore/test/aecore_naming_test.exs
+++ b/apps/aecore/test/aecore_naming_test.exs
@@ -17,6 +17,7 @@ defmodule AecoreNamingTest do
   setup do
     Code.require_file("test_utils.ex", "./test")
     TestUtils.clean_blockchain()
+
     on_exit(fn ->
       TestUtils.clean_blockchain()
     end)

--- a/apps/aecore/test/aecore_naming_test.exs
+++ b/apps/aecore/test/aecore_naming_test.exs
@@ -22,7 +22,7 @@ defmodule AecoreNamingTest do
     Pool.get_and_empty_pool()
 
     on_exit(fn ->
-      Persistence.delete_all_blocks()
+      Persistence.delete_all()
       Chain.clear_state()
       :ok
     end)

--- a/apps/aecore/test/aecore_oracle_test.exs
+++ b/apps/aecore/test/aecore_oracle_test.exs
@@ -11,6 +11,7 @@ defmodule AecoreOracleTest do
   setup do
     Code.require_file("test_utils.ex", "./test")
     TestUtils.clean_blockchain()
+
     on_exit(fn ->
       TestUtils.clean_blockchain()
     end)

--- a/apps/aecore/test/aecore_oracle_test.exs
+++ b/apps/aecore/test/aecore_oracle_test.exs
@@ -13,7 +13,7 @@ defmodule AecoreOracleTest do
     Code.require_file("test_utils.ex", "./test")
 
     on_exit(fn ->
-      Persistence.delete_all_blocks()
+      Persistence.delete_all()
       Chain.clear_state()
       Pool.get_and_empty_pool()
       :ok

--- a/apps/aecore/test/aecore_oracle_test.exs
+++ b/apps/aecore/test/aecore_oracle_test.exs
@@ -6,17 +6,13 @@ defmodule AecoreOracleTest do
   alias Aecore.Miner.Worker, as: Miner
   alias Aecore.Tx.Pool.Worker, as: Pool
   alias Aecore.Keys
-  alias Aecore.Persistence.Worker, as: Persistence
   alias Aeutil.PatriciaMerkleTree
 
   setup do
     Code.require_file("test_utils.ex", "./test")
-
+    TestUtils.clean_blockchain()
     on_exit(fn ->
-      Persistence.delete_all()
-      Chain.clear_state()
-      Pool.get_and_empty_pool()
-      :ok
+      TestUtils.clean_blockchain()
     end)
   end
 

--- a/apps/aecore/test/aecore_persistence_test.exs
+++ b/apps/aecore/test/aecore_persistence_test.exs
@@ -22,7 +22,6 @@ defmodule PersistenceTest do
   end
 
   setup do
-
     account1 = elem(Keys.keypair(:sign), 0)
 
     account2 =

--- a/apps/aecore/test/aecore_persistence_test.exs
+++ b/apps/aecore/test/aecore_persistence_test.exs
@@ -12,13 +12,16 @@ defmodule PersistenceTest do
   setup do
     Code.require_file("test_utils.ex", "./test")
     TestUtils.clean_blockchain()
+    :ok = Miner.mine_sync_block_to_chain()
+    :ok = Miner.mine_sync_block_to_chain()
+    :ok = Miner.mine_sync_block_to_chain()
+
     on_exit(fn ->
       TestUtils.clean_blockchain()
     end)
+  end
 
-    Miner.mine_sync_block_to_chain()
-    Miner.mine_sync_block_to_chain()
-    Miner.mine_sync_block_to_chain()
+  setup do
 
     account1 = elem(Keys.keypair(:sign), 0)
 
@@ -65,6 +68,9 @@ defmodule PersistenceTest do
   @tag :persistence
   test "Get latest two blocks from rocksdb" do
     top_height = Chain.top_height()
+
+    assert length(Map.values(Persistence.get_all_blocks())) == 4
+    assert length(Map.values(Persistence.get_blocks(2))) == 2
 
     [block1, block2] =
       Enum.sort(Map.values(Persistence.get_blocks(2)), fn b1, b2 ->

--- a/apps/aecore/test/aecore_persistence_test.exs
+++ b/apps/aecore/test/aecore_persistence_test.exs
@@ -20,7 +20,7 @@ defmodule PersistenceTest do
     Miner.mine_sync_block_to_chain()
 
     on_exit(fn ->
-      Persistence.delete_all_blocks()
+      Persistence.delete_all()
       Chain.clear_state()
       :ok
     end)

--- a/apps/aecore/test/aecore_persistence_test.exs
+++ b/apps/aecore/test/aecore_persistence_test.exs
@@ -10,20 +10,15 @@ defmodule PersistenceTest do
   alias Aecore.Account.{Account, AccountStateTree}
 
   setup do
-    Persistence.start_link([])
-    Miner.start_link([])
-
-    Chain.clear_state()
-
-    Miner.mine_sync_block_to_chain()
-    Miner.mine_sync_block_to_chain()
-    Miner.mine_sync_block_to_chain()
-
+    Code.require_file("test_utils.ex", "./test")
+    TestUtils.clean_blockchain()
     on_exit(fn ->
-      Persistence.delete_all()
-      Chain.clear_state()
-      :ok
+      TestUtils.clean_blockchain()
     end)
+
+    Miner.mine_sync_block_to_chain()
+    Miner.mine_sync_block_to_chain()
+    Miner.mine_sync_block_to_chain()
 
     account1 = elem(Keys.keypair(:sign), 0)
 

--- a/apps/aecore/test/aecore_pow_cuckoo_test.exs
+++ b/apps/aecore/test/aecore_pow_cuckoo_test.exs
@@ -13,7 +13,7 @@ defmodule AecoreCuckooTest do
 
   setup do
     on_exit(fn ->
-      Persistence.delete_all_blocks()
+      Persistence.delete_all()
       :ok
     end)
   end

--- a/apps/aecore/test/aecore_pow_cuckoo_test.exs
+++ b/apps/aecore/test/aecore_pow_cuckoo_test.exs
@@ -13,6 +13,7 @@ defmodule AecoreCuckooTest do
   setup do
     Code.require_file("test_utils.ex", "./test")
     TestUtils.clean_blockchain()
+
     on_exit(fn ->
       TestUtils.clean_blockchain()
     end)

--- a/apps/aecore/test/aecore_pow_cuckoo_test.exs
+++ b/apps/aecore/test/aecore_pow_cuckoo_test.exs
@@ -7,14 +7,14 @@ defmodule AecoreCuckooTest do
 
   use ExUnit.Case
 
-  alias Aecore.Persistence.Worker, as: Persistence
   alias Aecore.Pow.Cuckoo
   alias Aecore.Chain.{Block, Header}
 
   setup do
+    Code.require_file("test_utils.ex", "./test")
+    TestUtils.clean_blockchain()
     on_exit(fn ->
-      Persistence.delete_all()
-      :ok
+      TestUtils.clean_blockchain()
     end)
   end
 

--- a/apps/aecore/test/aecore_serializations_test.exs
+++ b/apps/aecore/test/aecore_serializations_test.exs
@@ -29,7 +29,7 @@ defmodule AecoreSerializationTest do
     Pool.get_and_empty_pool()
 
     on_exit(fn ->
-      Persistence.delete_all_blocks()
+      Persistence.delete_all()
       Chain.clear_state()
       Pool.get_and_empty_pool()
       :ok

--- a/apps/aecore/test/aecore_serializations_test.exs
+++ b/apps/aecore/test/aecore_serializations_test.exs
@@ -20,6 +20,7 @@ defmodule AecoreSerializationTest do
   setup do
     Code.require_file("test_utils.ex", "./test")
     TestUtils.clean_blockchain()
+
     on_exit(fn ->
       TestUtils.clean_blockchain()
     end)

--- a/apps/aecore/test/aecore_serializations_test.exs
+++ b/apps/aecore/test/aecore_serializations_test.exs
@@ -9,12 +9,9 @@ defmodule AecoreSerializationTest do
   alias Aecore.Account.Account
   alias Aecore.Chain.Worker, as: Chain
   alias Aecore.Tx.{DataTx, SignedTx}
-  alias Aecore.Tx.Pool.Worker, as: Pool
   alias Aecore.Keys
   alias Aecore.Account.Account
   alias Aecore.Miner.Worker, as: Miner
-  alias Aecore.Tx.Pool.Worker, as: Pool
-  alias Aecore.Persistence.Worker, as: Persistence
   alias Aecore.Chain.Block
   alias Aecore.Naming.{NameClaim, NameCommitment}
   alias Aecore.Naming.Tx.{NamePreClaimTx, NameClaimTx, NameUpdateTx.NameTransferTx}
@@ -22,17 +19,9 @@ defmodule AecoreSerializationTest do
 
   setup do
     Code.require_file("test_utils.ex", "./test")
-
-    Persistence.start_link([])
-    Miner.start_link([])
-    Chain.clear_state()
-    Pool.get_and_empty_pool()
-
+    TestUtils.clean_blockchain()
     on_exit(fn ->
-      Persistence.delete_all()
-      Chain.clear_state()
-      Pool.get_and_empty_pool()
-      :ok
+      TestUtils.clean_blockchain()
     end)
   end
 

--- a/apps/aecore/test/aecore_test_utils_test.exs
+++ b/apps/aecore/test/aecore_test_utils_test.exs
@@ -1,0 +1,36 @@
+defmodule AecoreTestUtilsTest do
+  @moduledoc """
+  Unit test for test_utils testing helper
+  """
+  use ExUnit.Case
+  alias Aecore.Keys
+  alias Aecore.Chain.Block
+  alias Aecore.Chain.Worker, as: Chain
+  alias Aecore.Account.Account
+
+  setup do
+    Code.require_file("test_utils.ex", "./test")
+  end
+
+  test "clean_blockchain" do
+    TestUtils.clean_blockchain()
+    check_is_clean()
+
+    TestUtils.assert_transactions_mined
+    TestUtils.assert_transactions_mined
+    TestUtils.assert_transactions_mined
+
+    {pubkey, _privkey} = Keys.keypair(:sign)
+    assert Account.balance(Chain.chain_state().accounts, pubkey) > 0
+
+    TestUtils.clean_blockchain()
+    check_is_clean()
+  end
+
+  def check_is_clean do
+    {pubkey, _privkey} = Keys.keypair(:sign)
+    assert Account.balance(Chain.chain_state().accounts, pubkey) == 0
+    assert Chain.top_height == 0
+    assert Chain.top_block == Block.genesis_block()
+  end
+end

--- a/apps/aecore/test/aecore_test_utils_test.exs
+++ b/apps/aecore/test/aecore_test_utils_test.exs
@@ -17,9 +17,9 @@ defmodule AecoreTestUtilsTest do
     TestUtils.clean_blockchain()
     check_is_clean()
 
-    TestUtils.assert_transactions_mined
-    TestUtils.assert_transactions_mined
-    TestUtils.assert_transactions_mined
+    TestUtils.assert_transactions_mined()
+    TestUtils.assert_transactions_mined()
+    TestUtils.assert_transactions_mined()
 
     {pubkey, _privkey} = Keys.keypair(:sign)
     assert Account.balance(Chain.chain_state().accounts, pubkey) > 0
@@ -31,7 +31,7 @@ defmodule AecoreTestUtilsTest do
   def check_is_clean do
     {pubkey, _privkey} = Keys.keypair(:sign)
     assert Account.balance(Chain.chain_state().accounts, pubkey) == 0
-    assert Chain.top_height == 0
-    assert Chain.top_block == Block.genesis_block()
+    assert Chain.top_height() == 0
+    assert Chain.top_block() == Block.genesis_block()
   end
 end

--- a/apps/aecore/test/aecore_test_utils_test.exs
+++ b/apps/aecore/test/aecore_test_utils_test.exs
@@ -10,6 +10,7 @@ defmodule AecoreTestUtilsTest do
 
   setup do
     Code.require_file("test_utils.ex", "./test")
+    :ok
   end
 
   test "clean_blockchain" do

--- a/apps/aecore/test/aecore_tx_test.exs
+++ b/apps/aecore/test/aecore_tx_test.exs
@@ -16,6 +16,7 @@ defmodule AecoreTxTest do
   setup do
     Code.require_file("test_utils.ex", "./test")
     TestUtils.clean_blockchain()
+
     on_exit(fn ->
       TestUtils.clean_blockchain()
     end)

--- a/apps/aecore/test/aecore_tx_test.exs
+++ b/apps/aecore/test/aecore_tx_test.exs
@@ -5,7 +5,6 @@ defmodule AecoreTxTest do
 
   use ExUnit.Case
 
-  alias Aecore.Persistence.Worker, as: Persistence
   alias Aecore.Chain.Worker, as: Chain
   alias Aecore.Miner.Worker, as: Miner
   alias Aecore.Tx.Pool.Worker, as: Pool
@@ -16,17 +15,9 @@ defmodule AecoreTxTest do
 
   setup do
     Code.require_file("test_utils.ex", "./test")
-
-    Persistence.start_link([])
-    Miner.start_link([])
-    Chain.clear_state()
-    Pool.get_and_empty_pool()
-
+    TestUtils.clean_blockchain()
     on_exit(fn ->
-      Persistence.delete_all()
-      Chain.clear_state()
-      Pool.get_and_empty_pool()
-      :ok
+      TestUtils.clean_blockchain()
     end)
   end
 

--- a/apps/aecore/test/aecore_tx_test.exs
+++ b/apps/aecore/test/aecore_tx_test.exs
@@ -23,7 +23,7 @@ defmodule AecoreTxTest do
     Pool.get_and_empty_pool()
 
     on_exit(fn ->
-      Persistence.delete_all_blocks()
+      Persistence.delete_all()
       Chain.clear_state()
       Pool.get_and_empty_pool()
       :ok

--- a/apps/aecore/test/aecore_txs_pool_test.exs
+++ b/apps/aecore/test/aecore_txs_pool_test.exs
@@ -24,7 +24,7 @@ defmodule AecoreTxsPoolTest do
     Chain.clear_state()
 
     on_exit(fn ->
-      Persistence.delete_all_blocks()
+      Persistence.delete_all()
       Chain.clear_state()
       :ok
     end)

--- a/apps/aecore/test/aecore_txs_pool_test.exs
+++ b/apps/aecore/test/aecore_txs_pool_test.exs
@@ -4,7 +4,6 @@ defmodule AecoreTxsPoolTest do
   """
   use ExUnit.Case
 
-  alias Aecore.Persistence.Worker, as: Persistence
   alias Aecore.Tx.Pool.Worker, as: Pool
   alias Aecore.Miner.Worker, as: Miner
   alias Aecore.Chain.Worker, as: Chain
@@ -21,14 +20,13 @@ defmodule AecoreTxsPoolTest do
       File.rm_rf(path)
     end
 
-    Chain.clear_state()
-
+    TestUtils.clean_blockchain()
     on_exit(fn ->
-      Persistence.delete_all()
-      Chain.clear_state()
-      :ok
+      TestUtils.clean_blockchain()
     end)
+  end
 
+  setup do
     %{public: b_pub_key} = :enacl.sign_keypair()
     {pubkey, privkey} = Keys.keypair(:sign)
 

--- a/apps/aecore/test/aecore_txs_pool_test.exs
+++ b/apps/aecore/test/aecore_txs_pool_test.exs
@@ -21,6 +21,7 @@ defmodule AecoreTxsPoolTest do
     end
 
     TestUtils.clean_blockchain()
+
     on_exit(fn ->
       TestUtils.clean_blockchain()
     end)

--- a/apps/aecore/test/aecore_validation_test.exs
+++ b/apps/aecore/test/aecore_validation_test.exs
@@ -24,7 +24,7 @@ defmodule AecoreValidationTest do
     end
 
     on_exit(fn ->
-      Persistence.delete_all_blocks()
+      Persistence.delete_all()
       Chain.clear_state()
       :ok
     end)

--- a/apps/aecore/test/aecore_validation_test.exs
+++ b/apps/aecore/test/aecore_validation_test.exs
@@ -6,7 +6,6 @@ defmodule AecoreValidationTest do
   use ExUnit.Case
   doctest Aecore.Chain.BlockValidation
 
-  alias Aecore.Persistence.Worker, as: Persistence
   alias Aecore.Chain.BlockValidation
   alias Aecore.Chain.{Block, Header}
   alias Aecore.Chain.Worker, as: Chain
@@ -17,6 +16,8 @@ defmodule AecoreValidationTest do
 
   setup_all do
     Code.require_file("test_utils.ex", "./test")
+    TestUtils.clean_blockchain()
+
     path = Application.get_env(:aecore, :persistence)[:path]
 
     if File.exists?(path) do
@@ -24,9 +25,7 @@ defmodule AecoreValidationTest do
     end
 
     on_exit(fn ->
-      Persistence.delete_all()
-      Chain.clear_state()
-      :ok
+      TestUtils.clean_blockchain()
     end)
   end
 

--- a/apps/aecore/test/multiple_transactions_test.exs
+++ b/apps/aecore/test/multiple_transactions_test.exs
@@ -15,6 +15,7 @@ defmodule MultipleTransactionsTest do
   setup do
     Code.require_file("test_utils.ex", "./test")
     TestUtils.clean_blockchain()
+
     on_exit(fn ->
       TestUtils.clean_blockchain()
     end)

--- a/apps/aecore/test/multiple_transactions_test.exs
+++ b/apps/aecore/test/multiple_transactions_test.exs
@@ -5,7 +5,6 @@ defmodule MultipleTransactionsTest do
 
   use ExUnit.Case
 
-  alias Aecore.Persistence.Worker, as: Persistence
   alias Aecore.Tx.Pool.Worker, as: Pool
   alias Aecore.Miner.Worker, as: Miner
   alias Aecore.Chain.Worker, as: Chain
@@ -15,15 +14,13 @@ defmodule MultipleTransactionsTest do
 
   setup do
     Code.require_file("test_utils.ex", "./test")
-
+    TestUtils.clean_blockchain()
     on_exit(fn ->
-      Persistence.delete_all()
-      Chain.clear_state()
-      :ok
+      TestUtils.clean_blockchain()
     end)
+  end
 
-    Pool.start_link([])
-
+  setup do
     %{public: acc2_pub, secret: acc2_priv} = :enacl.sign_keypair()
     %{public: acc3_pub, secret: acc3_priv} = :enacl.sign_keypair()
     %{public: acc4_pub, secret: acc4_priv} = :enacl.sign_keypair()

--- a/apps/aecore/test/multiple_transactions_test.exs
+++ b/apps/aecore/test/multiple_transactions_test.exs
@@ -17,7 +17,7 @@ defmodule MultipleTransactionsTest do
     Code.require_file("test_utils.ex", "./test")
 
     on_exit(fn ->
-      Persistence.delete_all_blocks()
+      Persistence.delete_all()
       Chain.clear_state()
       :ok
     end)

--- a/apps/aecore/test/test_utils.ex
+++ b/apps/aecore/test/test_utils.ex
@@ -52,10 +52,16 @@ defmodule TestUtils do
     assert Enum.empty?(Pool.get_and_empty_pool()) == true
   end
 
+  defp restart_supervisor(supervisor) do
+    :ok = Supervisor.terminate_child(Aecore, supervisor)
+    {:ok, _} = Supervisor.restart_child(Aecore, supervisor)
+  end
+
   def clean_blockchain do
     :ok = Persistence.delete_all()
-    :ok = Chain.clear_state()
-    Pool.get_and_empty_pool()
+    restart_supervisor(Aecore.Channel.Worker.Supervisor)
+    restart_supervisor(Aecore.Chain.Worker.Supervisor)
+    restart_supervisor(Aecore.Tx.Pool.Worker.Supervisor)
     :ok
   end
 end

--- a/apps/aecore/test/test_utils.ex
+++ b/apps/aecore/test/test_utils.ex
@@ -48,7 +48,7 @@ defmodule TestUtils do
   end
 
   def assert_transactions_mined do
-    Miner.mine_sync_block_to_chain()
+    :ok = Miner.mine_sync_block_to_chain()
     assert Enum.empty?(Pool.get_and_empty_pool()) == true
   end
 

--- a/apps/aecore/test/test_utils.ex
+++ b/apps/aecore/test/test_utils.ex
@@ -53,8 +53,8 @@ defmodule TestUtils do
   end
 
   def clean_blockchain do
-    Persistence.delete_all_blocks()
-    Chain.clear_state()
+    :ok = Persistence.delete_all()
+    :ok = Chain.clear_state()
     Pool.get_and_empty_pool()
     :ok
   end


### PR DESCRIPTION
This changes how we clean blockchain (used in tests) so cleaning doesn't result in inconsistency.

Details:
- Removed old delete functions from `Aecore.Persiatance.Worker`
- Added `delete_all` to `Aecore.Peristance.Worker`
- Fixed `Exexec` starting so Aecore can be stoped now
- Fixed bug in `Perisatance.get_blocks`
- Removed duplication of blockchain cleaning code
- Tests for blockchain cleaning code

This fixes #534 