### PR TITLE
[GH-647] Fixed Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,7 @@
 dist: xenial
 language: elixir
-elixir:
-  - 1.6.4
-otp_release:
-  - 20.2.2
+elixir: 1.6.4
+otp_release: 20.3.8
 
 env:
   - MIX_ENV=test LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$HOME/.libsodium/lib:$HOME/.libsodium/include PATH=$PATH:$HOME/.libsodium/lib:$HOME/.libsodium/include LIBRARY_PATH=$LIBRARY_PATH:$HOME/.libsodium/lib:$HOME/.libsodium/include C_INCLUDE_PATH=$C_INCLUDE_PATH:$HOME/.libsodium/lib:$HOME/.libsodium/include


### PR DESCRIPTION
Travis currently fails on master. Used OTP version is no longer available in Travis. Updated OTP to 20.3.8.

This fixes #647 