### PR TITLE
[GH-647] Fixed travis and optimized the buildtime

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,18 @@
 dist: xenial
-language: elixir
-elixir: 1.6.6
+language: erlang
+#elixir: 1.6.6
 otp_release: 20.3.8
 
 env:
-  - MIX_ENV=test LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$HOME/.libsodium/lib:$HOME/.libsodium/include PATH=$PATH:$HOME/.libsodium/lib:$HOME/.libsodium/include LIBRARY_PATH=$LIBRARY_PATH:$HOME/.libsodium/lib:$HOME/.libsodium/include C_INCLUDE_PATH=$C_INCLUDE_PATH:$HOME/.libsodium/lib:$HOME/.libsodium/include
+  - MIX_ENV=test LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$HOME/.libsodium/lib:$HOME/.libsodium/include PATH=$PATH:$HOME/.libsodium/lib:$HOME/.libsodium/include:$HOME/.kiex LIBRARY_PATH=$LIBRARY_PATH:$HOME/.libsodium/lib:$HOME/.libsodium/include C_INCLUDE_PATH=$C_INCLUDE_PATH:$HOME/.libsodium/lib:$HOME/.libsodium/include
 
 before_install:
+  # Install elixir
+  - curl -sSL https://raw.githubusercontent.com/taylor/kiex/master/install | bash -s
+  - kiex install 1.6.6
+  - kiex default 1.6.6
+  - kiex use 1.6.6
+
   - wget -O libsodium-src.tar.gz https://github.com/jedisct1/libsodium/releases/download/1.0.16/libsodium-1.0.16.tar.gz
   - "[ -d libsodium-src ] || mkdir libsodium-src && tar -zxf libsodium-src.tar.gz -C libsodium-src --strip-components=1"
   - cd libsodium-src && ./configure --prefix=$HOME/.libsodium && make -j$(nproc) && make install && cd ..
@@ -22,6 +28,7 @@ script:
 
 cache:
   directories:
+    - $HOME/.kiex
     - $HOME/.cargo
     - deps
     - _build

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 dist: xenial
 language: elixir
-elixir: 1.6.4
+elixir: 1.6.6
 otp_release: 20.3.8
 
 env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ install:
   - cd ..
 
   # Recompile enacl if necessary
-  - "[ -z '${LIBSODIUM_NEW}' ] || (mix deps.compile enacl)"
+  - "[ -z $LIBSODIUM_NEW ] || (mix deps.compile enacl)"
 
   # Install rust
   - curl https://sh.rustup.rs -sSf | sh -s -- -y

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,7 @@
 dist: xenial
 language: elixir
-elixir:
-  - 1.6.4
-otp_release:
-  - 20.2.2
+elixir: 1.6.4
+otp_release: 20.3.8
 
 env:
   - MIX_ENV=test LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$HOME/.libsodium/lib:$HOME/.libsodium/include PATH=$PATH:$HOME/.libsodium/lib:$HOME/.libsodium/include LIBRARY_PATH=$LIBRARY_PATH:$HOME/.libsodium/lib:$HOME/.libsodium/include C_INCLUDE_PATH=$C_INCLUDE_PATH:$HOME/.libsodium/lib:$HOME/.libsodium/include

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,8 +38,8 @@ install:
   - curl https://sh.rustup.rs -sSf | sh -s -- -y
   - source $HOME/.cargo/env
 
-  # Fetch aevm tests
-  - make aevm-test-deps
+  # Fetch aevm tests if they are missing from the cache
+  - "[ -d aevm_external/ethereum_tests/VMTests/vmArithmeticTest ] || (make aevm-test-deps)"
 
 script:
   - mix compile --warnings-as-errors
@@ -54,6 +54,6 @@ cache:
     - $HOME/.libsodium
     - deps
     - _build
-    - aevm_external
+    - aevm_external/ethereum_tests/VMTests
     - apps/aecore/src/cuckoo/c_src
     - apps/aecore/priv/cuckoo

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,23 +1,44 @@
-dist: xenial
+dist: trusty
+sudo: false
 language: erlang
-#elixir: 1.6.6
-otp_release: 20.3.8
+otp_release: 20.2.2
 
 env:
-  - MIX_ENV=test LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$HOME/.libsodium/lib:$HOME/.libsodium/include PATH=$PATH:$HOME/.libsodium/lib:$HOME/.libsodium/include:$HOME/.kiex LIBRARY_PATH=$LIBRARY_PATH:$HOME/.libsodium/lib:$HOME/.libsodium/include C_INCLUDE_PATH=$C_INCLUDE_PATH:$HOME/.libsodium/lib:$HOME/.libsodium/include
+  global:
+    - LD_LIBRARY_PATH=$HOME/.libsodium/lib:$LD_LIBRARY_PATH
+    - LD_RUN_PATH=$HOME/.libsodium/lib:$LD_RUN_PATH
+    - PATH=$PATH:$HOME/.libsodium/lib:$HOME/.libsodium/include:$HOME/.kiex
+    - LIBRARY_PATH=$HOME/.libsodium/lib:$LIBRARY_PATH
+    - C_INCLUDE_PATH=$HOME/.libsodium/include:$C_INCLUDE_PATH
+  matrix:
+    - MIX_ENV=test ELIXIR_VER=1.6.4 LIBSODIUM_VER=1.0.16
 
 before_install:
   # Install elixir
   - curl -sSL https://raw.githubusercontent.com/taylor/kiex/master/install | bash -s
-  - kiex install 1.6.6
-  - kiex default 1.6.6
-  - kiex use 1.6.6
+  - "[ -d $HOME/.kiex/builds/elixir-git ] || (eval kiex install $ELIXIR_VER)"
+  - kiex default $ELIXIR_VER
+  - kiex use $ELIXIR_VER
+  - mix local.hex --force
+  - mix local.rebar --force
+  - mix deps.get
 
-  - wget -O libsodium-src.tar.gz https://github.com/jedisct1/libsodium/releases/download/1.0.16/libsodium-1.0.16.tar.gz
-  - "[ -d libsodium-src ] || mkdir libsodium-src && tar -zxf libsodium-src.tar.gz -C libsodium-src --strip-components=1"
-  - cd libsodium-src && ./configure --prefix=$HOME/.libsodium && make -j$(nproc) && make install && cd ..
+install:
+  # Install libsodium
+  - mkdir -p libsodium-src
+  - "[ -d $HOME/.libsodium/lib ] || (wget -O libsodium-src.tar.gz https://github.com/jedisct1/libsodium/releases/download/$LIBSODIUM_VER/libsodium-$LIBSODIUM_VER.tar.gz && tar -zxf libsodium-src.tar.gz -C libsodium-src --strip-components=1)"
+  - cd libsodium-src
+  - "[ -d $HOME/.libsodium/lib ] || (./configure --prefix=$HOME/.libsodium && make -j$(nproc) && make install && export LIBSODIUM_NEW=yes)"
+  - cd ..
+
+  # Recompile enacl if necessary
+  - "[ -z '${LIBSODIUM_NEW}' ] || (mix deps.compile enacl)"
+
+  # Install rust
   - curl https://sh.rustup.rs -sSf | sh -s -- -y
   - source $HOME/.cargo/env
+
+  # Fetch aevm tests
   - make aevm-test-deps
 
 script:
@@ -30,9 +51,9 @@ cache:
   directories:
     - $HOME/.kiex
     - $HOME/.cargo
+    - $HOME/.libsodium
     - deps
     - _build
     - aevm_external
     - apps/aecore/src/cuckoo/c_src
     - apps/aecore/priv/cuckoo
-    - libsodium-src


### PR DESCRIPTION
If the cache is present the build takes around 2.5 minutes to complete. Without the cache the build takes 12 mins. This fixes issue #647. The optimizations in this PR are: removing unnecessary items from the build cache, fully caching elixir and libsodium. I've cleanup'd the environment variables.