### PR TITLE
[GH-602] Testframework stability fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -63,7 +63,7 @@ iex-node:
 	@PERSISTENCE_PATH=apps/aecore/priv/rox_db_400$(NODE_NUMBER)/ PEER_KEYS_PATH=apps/aecore/priv/peerkeys_400$(NODE_NUMBER)/ SIGN_KEYS_PATH=apps/aecore/priv/signkeys_400$(NODE_NUMBER)/ PORT=400$(NODE_NUMBER) SYNC_PORT=300$(NODE_NUMBER) iex -S mix phx.server
 
 iex-test-node:
-	@PERSISTENCE_PATH=apps/aecore/priv/test_rox_db_400$(NODE_NUMBER)/ PEER_KEYS_PATH=apps/aecore/priv/test_peerkeys_400$(NODE_NUMBER)/ SIGN_KEYS_PATH=apps/aecore/priv/test_signkeys_400$(NODE_NUMBER)/ PORT=400$(NODE_NUMBER) SYNC_PORT=300$(NODE_NUMBER) iex -S mix phx.server
+	@MIX_ENV=test PERSISTENCE_PATH=apps/aecore/priv/test_rox_db_400$(NODE_NUMBER)/ PEER_KEYS_PATH=apps/aecore/priv/test_peerkeys_400$(NODE_NUMBER)/ SIGN_KEYS_PATH=apps/aecore/priv/test_signkeys_400$(NODE_NUMBER)/ PORT=400$(NODE_NUMBER) SYNC_PORT=300$(NODE_NUMBER) iex -S mix phx.server
 
 #
 # utility

--- a/Makefile
+++ b/Makefile
@@ -66,7 +66,7 @@ PORT = $$(( 4000 + $(NODE_NUMBER) ))
 SYNC_PORT = $$(( 3000 + $(NODE_NUMBER) ))
 
 iex-test-node:
-	@PERSISTENCE_PATH=apps/aecore/priv/test_rox_db_400$(NODE_NUMBER)/ PEER_KEYS_PATH=apps/aecore/priv/test_peerkeys_$(PORT)/ SIGN_KEYS_PATH=apps/aecore/priv/test_signkeys_$(PORT)/ PORT=$(PORT) SYNC_PORT=$(SYNC_PORT) iex -S mix phx.server
+	@MIX_ENV=test PERSISTENCE_PATH=apps/aecore/priv/test_rox_db_400$(NODE_NUMBER)/ PEER_KEYS_PATH=apps/aecore/priv/test_peerkeys_$(PORT)/ SIGN_KEYS_PATH=apps/aecore/priv/test_signkeys_$(PORT)/ PORT=$(PORT) SYNC_PORT=$(SYNC_PORT) iex -S mix phx.server
 
 #
 # utility

--- a/Makefile
+++ b/Makefile
@@ -62,8 +62,11 @@ iex-node:
 	@rm -rf apps/aecore/priv/rox_db_400$(NODE_NUMBER)
 	@PERSISTENCE_PATH=apps/aecore/priv/rox_db_400$(NODE_NUMBER)/ PEER_KEYS_PATH=apps/aecore/priv/peerkeys_400$(NODE_NUMBER)/ SIGN_KEYS_PATH=apps/aecore/priv/signkeys_400$(NODE_NUMBER)/ PORT=400$(NODE_NUMBER) SYNC_PORT=300$(NODE_NUMBER) iex -S mix phx.server
 
+PORT = $$(( 4000 + $(NODE_NUMBER) ))
+SYNC_PORT = $$(( 3000 + $(NODE_NUMBER) ))
+
 iex-test-node:
-	@MIX_ENV=test PERSISTENCE_PATH=apps/aecore/priv/test_rox_db_400$(NODE_NUMBER)/ PEER_KEYS_PATH=apps/aecore/priv/test_peerkeys_400$(NODE_NUMBER)/ SIGN_KEYS_PATH=apps/aecore/priv/test_signkeys_400$(NODE_NUMBER)/ PORT=400$(NODE_NUMBER) SYNC_PORT=300$(NODE_NUMBER) iex -S mix phx.server
+	@PERSISTENCE_PATH=apps/aecore/priv/test_rox_db_400$(NODE_NUMBER)/ PEER_KEYS_PATH=apps/aecore/priv/test_peerkeys_$(PORT)/ SIGN_KEYS_PATH=apps/aecore/priv/test_signkeys_$(PORT)/ PORT=$(PORT) SYNC_PORT=$(SYNC_PORT) iex -S mix phx.server
 
 #
 # utility

--- a/apps/aetestframework/lib/utils.ex
+++ b/apps/aetestframework/lib/utils.ex
@@ -17,11 +17,10 @@ defmodule Aetestframework.Utils do
     end)
   end
 
-  def get_tx_from_pool(node) do
-    case TestFramework.get(pool_cmd(), :txs_pool_cmd, node) do
-      txs when txs == %{} -> false
-      txs -> hd(Map.values(txs)).data.type
-    end
+  def has_type_in_pool?(node, tx_type) do
+    TestFramework.get(pool_cmd(), :txs_pool_cmd, node)
+    |> Map.values()
+    |> Enum.any?(fn tx -> tx.data.type == tx_type end)
   end
 
   def connect_to_peer_cmd(sync_port, pubkey) do

--- a/apps/aetestframework/lib/utils.ex
+++ b/apps/aetestframework/lib/utils.ex
@@ -140,8 +140,8 @@ defmodule Aetestframework.Utils do
   end
 
   def find_port(start_port) do
-    if TestFramework.busy_port?("300#{start_port}") ||
-         TestFramework.busy_port?("400#{start_port}") do
+    if TestFramework.busy_port?("#{3000 + start_port}") ||
+         TestFramework.busy_port?("#{4000 + start_port}") do
       find_port(start_port + 1)
     else
       start_port

--- a/apps/aetestframework/lib/utils.ex
+++ b/apps/aetestframework/lib/utils.ex
@@ -18,7 +18,8 @@ defmodule Aetestframework.Utils do
   end
 
   def has_type_in_pool?(node, tx_type) do
-    TestFramework.get(pool_cmd(), :txs_pool_cmd, node)
+    pool_cmd()
+    |> TestFramework.get(:txs_pool_cmd, node)
     |> Map.values()
     |> Enum.any?(fn tx -> tx.data.type == tx_type end)
   end

--- a/apps/aetestframework/lib/worker.ex
+++ b/apps/aetestframework/lib/worker.ex
@@ -123,12 +123,13 @@ defmodule Aetestframework.Worker do
         {:reply, return, new_state}
 
       new_state ->
-        Enum.reduce(nodes, :ok, fn {node_name, _iex_num}, :ok ->
-          expected_result = fn _ -> :node_started end
-          %{port_id: port_id} = Map.get(new_state, node_name)
-          :node_started = receive_result(port_id, "Interactive Elixir", expected_result)
-          :ok
-        end)
+        :ok =
+          Enum.reduce(nodes, :ok, fn {node_name, _iex_num}, :ok ->
+            expected_result = fn _ -> :node_started end
+            %{port_id: port_id} = Map.get(new_state, node_name)
+            :node_started = receive_result(port_id, "Interactive Elixir", expected_result)
+            :ok
+          end)
 
         {:reply, :ok, new_state}
     end

--- a/apps/aetestframework/lib/worker.ex
+++ b/apps/aetestframework/lib/worker.ex
@@ -201,7 +201,7 @@ defmodule Aetestframework.Worker do
         if result =~ key do
           fun.(result)
         else
-          receive_result(key, fun)
+          receive_result(port, key, fun)
         end
     end
   end

--- a/apps/aetestframework/lib/worker.ex
+++ b/apps/aetestframework/lib/worker.ex
@@ -25,7 +25,11 @@ defmodule Aetestframework.Worker do
   """
   @spec new_node(atom(), non_neg_integer()) :: :ok
   def new_node(node_name, iex_num) do
-    GenServer.call(__MODULE__, {:new_node, node_name, iex_num}, @new_node_timeout)
+    GenServer.call(__MODULE__, {:new_nodes, [{node_name, iex_num}]}, @new_node_timeout)
+  end
+
+  def new_nodes(nodes) do
+    GenServer.call(__MODULE__, {:new_nodes, nodes}, @new_node_timeout)
   end
 
   @doc """
@@ -60,16 +64,20 @@ defmodule Aetestframework.Worker do
   Call a GenServer API function with specific delay
   """
   @spec verify_with_delay(reference(), non_neg_integer()) :: any
-  def verify_with_delay(valid?, 0) do
+  def verify_with_delay(valid?, execute_times) do
+    verify_with_delay_int(valid?, execute_times * 100)
+  end
+
+  def verify_with_delay_int(valid?, 0) do
     valid?.()
   end
 
-  def verify_with_delay(valid?, execute_times) do
+  def verify_with_delay_int(valid?, execute_times) do
     if valid?.() do
       true
     else
-      :timer.sleep(500)
-      verify_with_delay(valid?, execute_times - 1)
+      :timer.sleep(10)
+      verify_with_delay_int(valid?, execute_times - 1)
     end
   end
 
@@ -83,30 +91,44 @@ defmodule Aetestframework.Worker do
     {:reply, state, state}
   end
 
-  def handle_call({:new_node, node_name, iex_num}, _from, state) do
-    cond do
-      Map.has_key?(state, node_name) ->
-        {:reply, :already_exists, state}
+  def handle_call({:new_nodes, nodes}, _from, state) do
+    case Enum.reduce_while(nodes, state, fn {node_name, iex_num}, state ->
+           cond do
+             Map.has_key?(state, node_name) ->
+               {:halt, {:error, :already_exists, state}}
 
-      busy_port?("300#{iex_num}") || busy_port?("400#{iex_num}") ->
-        {:reply, :busy_port, state}
+             busy_port?("300#{iex_num}") || busy_port?("400#{iex_num}") ->
+               {:halt, {:error, :busy_port, state}}
 
-      true ->
-        # Running the new elixir-node using Port
-        port_id =
-          Port.open({:spawn, "make iex-test-node NODE_NUMBER=#{iex_num}"}, [
-            :binary,
-            cd: project_dir()
-          ])
+             true ->
+               # Running the new elixir-node using Port
+               port_id =
+                 Port.open({:spawn, "make iex-test-node NODE_NUMBER=#{iex_num}"}, [
+                   :binary,
+                   cd: project_dir()
+                 ])
 
-        port = String.to_integer("400#{iex_num}")
-        sync_port = String.to_integer("300#{iex_num}")
+               port = String.to_integer("400#{iex_num}")
+               sync_port = String.to_integer("300#{iex_num}")
 
-        expected_result = fn _ -> :node_started end
-        :node_started = receive_result("Interactive Elixir", expected_result)
+               new_node =
+                 __MODULE__.new(%{port_id: port_id, node_port: port, sync_port: sync_port})
 
-        new_node = __MODULE__.new(%{port_id: port_id, node_port: port, sync_port: sync_port})
-        new_state = Map.put(state, node_name, new_node)
+               new_state = Map.put(state, node_name, new_node)
+
+               {:cont, new_state}
+           end
+         end) do
+      {:error, return, new_state} ->
+        {:reply, return, new_state}
+
+      new_state ->
+        Enum.reduce(nodes, :ok, fn {node_name, _iex_num}, :ok ->
+          expected_result = fn _ -> :node_started end
+          %{port_id: port_id} = Map.get(new_state, node_name)
+          :node_started = receive_result(port_id, "Interactive Elixir", expected_result)
+          :ok
+        end)
 
         {:reply, :ok, new_state}
     end
@@ -130,10 +152,15 @@ defmodule Aetestframework.Worker do
   end
 
   def handle_call(:delete_nodes, _from, state) do
+    Enum.each(state, fn {_node, %{port_id: port_id}} ->
+      {:os_pid, pid} = Port.info(port_id, :os_pid)
+      System.cmd("kill", ["#{pid}"])
+      # Port.command(port_id, "{:stop, System.stop()}\n")
+    end)
+
     Enum.each(state, fn {_node, %{port_id: port_id, node_port: port}} ->
-      Port.command(port_id, "{:stop, System.stop()}\n")
-      expected_result = fn _ -> :ok end
-      :ok = receive_result(":stop", expected_result)
+      #  expected_result = fn _ -> :ok end
+      #  :ok = receive_result(port_id, ":stop", expected_result)
       Port.close(port_id)
       path_to_priv_dir = project_dir() <> "/apps/aecore/priv/"
       File.rm_rf(path_to_priv_dir <> "test_signkeys_#{port}")
@@ -170,12 +197,23 @@ defmodule Aetestframework.Worker do
     end
   end
 
+  defp receive_result(port, key, fun) do
+    receive do
+      {^port, {:data, result}} ->
+        if result =~ key do
+          fun.(result)
+        else
+          receive_result(key, fun)
+        end
+    end
+  end
+
   @doc """
   Checking if the port is busy
   """
   @spec busy_port?(non_neg_integer()) :: true | false
   def busy_port?(port) do
-    :os.cmd('lsof -i -P -n | grep -w #{port}') != []
+    :os.cmd('lsof -Pi :#{port} -sTCP:LISTEN -t') != []
   end
 
   @doc """

--- a/apps/aetestframework/mix.exs
+++ b/apps/aetestframework/mix.exs
@@ -6,13 +6,20 @@ defmodule Aetestframework.MixProject do
       app: :aetestframework,
       version: "0.1.0",
       elixir: "~> 1.6",
-      start_permanent: Mix.env() == :prod
+      start_permanent: Mix.env() == :prod,
+      deps: deps()
     ]
   end
 
   def application do
     [
       extra_applications: [:logger]
+    ]
+  end
+
+  defp deps do
+    [
+      {:exconstructor, "~> 1.1"}
     ]
   end
 end

--- a/apps/aetestframework/test/multi_node_sync_test.exs
+++ b/apps/aetestframework/test/multi_node_sync_test.exs
@@ -58,15 +58,7 @@ defmodule MultiNodeSyncTest do
     TestFramework.post(Utils.simulate_spend_tx_cmd(), :spend_tx_cmd, :node1)
 
     # Check that Spend transaction is added to the pool
-    assert TestFramework.verify_with_delay(
-             fn ->
-               Utils.get_tx_from_pool(:node1) == SpendTx &&
-                 Utils.get_tx_from_pool(:node2) == SpendTx &&
-                 Utils.get_tx_from_pool(:node3) == SpendTx &&
-                 Utils.get_tx_from_pool(:node4) == SpendTx
-             end,
-             5
-           ) == true
+    assert transaction_added_to_pool(SpendTx)
 
     Utils.mine_blocks(1, :node1)
 
@@ -78,6 +70,7 @@ defmodule MultiNodeSyncTest do
   @tag timeout: 100_000
   test "oracles test" do
     Utils.mine_blocks(1, :node2)
+    assert same_top_header_hash() == true
 
     # Create an Oracle Register transaction and add it to the pool
     TestFramework.post(Utils.oracle_register_cmd(), :oracle_register_cmd, :node2)
@@ -86,6 +79,7 @@ defmodule MultiNodeSyncTest do
     assert transaction_added_to_pool(OracleRegistrationTx) == true
 
     Utils.mine_blocks(1, :node2)
+    assert same_top_header_hash() == true
 
     # Create an Oracle Query transaction and add it to the pool
     query_ttl = "%{ttl: 10, type: :relative}"
@@ -96,6 +90,7 @@ defmodule MultiNodeSyncTest do
     assert transaction_added_to_pool(OracleQueryTx) == true
 
     Utils.mine_blocks(1, :node2)
+    assert same_top_header_hash() == true
 
     %Aecore.Chain.Block{txs: txs} =
       TestFramework.get(Utils.top_block_cmd(), :top_block_cmd, :node2)
@@ -124,6 +119,7 @@ defmodule MultiNodeSyncTest do
     assert transaction_added_to_pool(OracleResponseTx) == true
 
     Utils.mine_blocks(1, :node2)
+    assert same_top_header_hash() == true
 
     # Create OracleExtend transaction and add it to the pool
     TestFramework.post(Utils.oracle_extend_cmd(), :oracle_extend_cmd, :node2)
@@ -132,8 +128,6 @@ defmodule MultiNodeSyncTest do
     assert transaction_added_to_pool(OracleExtendTx) == true
 
     Utils.mine_blocks(1, :node2)
-
-    # Check if the top Header hash is equal among the nodes
     assert same_top_header_hash() == true
   end
 
@@ -141,8 +135,6 @@ defmodule MultiNodeSyncTest do
   @tag timeout: 100_000
   test "namings test" do
     Utils.mine_blocks(1, :node2)
-
-    # Check that top block is equal among the nodes
     assert same_top_header_hash() == true
 
     # Create a Naming PreClaim transaction and add it to the pool
@@ -152,8 +144,6 @@ defmodule MultiNodeSyncTest do
     assert transaction_added_to_pool(NamePreClaimTx) == true
 
     Utils.mine_blocks(1, :node2)
-
-    # Check that top block is equal among the nodes
     assert same_top_header_hash() == true
 
     # Check that NameClaim transaction is added to the pool
@@ -162,8 +152,6 @@ defmodule MultiNodeSyncTest do
     assert transaction_added_to_pool(NameClaimTx) == true
 
     Utils.mine_blocks(1, :node2)
-
-    # Check that top block is equal among the nodes
     assert same_top_header_hash() == true
 
     # Create a Naming Update transaction and add it to the pool
@@ -173,8 +161,6 @@ defmodule MultiNodeSyncTest do
     assert transaction_added_to_pool(NameUpdateTx) == true
 
     Utils.mine_blocks(1, :node2)
-
-    # Check that top block is equal among the nodes
     assert same_top_header_hash() == true
 
     {node2_pub, node2_priv} = TestFramework.get(Utils.sign_keys_cmd(), :keypair_cmd, :node2)
@@ -186,8 +172,6 @@ defmodule MultiNodeSyncTest do
     assert transaction_added_to_pool(NameTransferTx) == true
 
     Utils.mine_blocks(1, :node2)
-
-    # Check that top block is equal among the nodes
     assert same_top_header_hash() == true
 
     # Create a Naming Revoke transaction and add it to the pool
@@ -197,8 +181,6 @@ defmodule MultiNodeSyncTest do
     assert transaction_added_to_pool(NameRevokeTx) == true
 
     Utils.mine_blocks(1, :node2)
-
-    # Check if the top Header hash is equal among the nodes
     assert same_top_header_hash() == true
   end
 
@@ -212,7 +194,6 @@ defmodule MultiNodeSyncTest do
 
     # Mine 2 blocks, so that node1 has enough tokens to spend
     Utils.mine_blocks(2, :node1)
-
     assert same_top_header_hash() == true
 
     assert TestFramework.verify_with_delay(
@@ -247,7 +228,6 @@ defmodule MultiNodeSyncTest do
     assert transaction_added_to_pool(SpendTx) == true
 
     Utils.mine_blocks(1, :node1)
-
     assert same_top_header_hash() == true
 
     assert TestFramework.verify_with_delay(
@@ -279,7 +259,6 @@ defmodule MultiNodeSyncTest do
     assert transaction_added_to_pool(SpendTx) == true
 
     Utils.mine_blocks(1, :node3)
-
     assert same_top_header_hash() == true
 
     assert TestFramework.verify_with_delay(
@@ -311,7 +290,6 @@ defmodule MultiNodeSyncTest do
     assert transaction_added_to_pool(SpendTx) == true
 
     Utils.mine_blocks(1, :node2)
-
     assert same_top_header_hash() == true
 
     # Check that all nodes have correct amount
@@ -345,7 +323,7 @@ defmodule MultiNodeSyncTest do
   defp transaction_added_to_pool(tx_type) do
     TestFramework.verify_with_delay(
       fn ->
-        Utils.get_tx_from_pool(:node2) == tx_type
+        Utils.has_type_in_pool?(:node2, tx_type)
       end,
       5
     )

--- a/apps/aetestframework/test/multi_node_sync_test.exs
+++ b/apps/aetestframework/test/multi_node_sync_test.exs
@@ -15,7 +15,7 @@ defmodule MultiNodeSyncTest do
   end
 
   setup do
-    :ok = TestFramework.new_nodes([{:node1, 5}, {:node2, 6}, {:node3, 7}, {:node4, 8}])
+    :ok = TestFramework.new_nodes([{:node1, 2}, {:node2, 3}, {:node3, 4}, {:node4, 5}])
 
     Utils.sync_nodes(:node1, :node2)
     Utils.sync_nodes(:node2, :node3)

--- a/apps/aetestframework/test/multi_node_sync_test.exs
+++ b/apps/aetestframework/test/multi_node_sync_test.exs
@@ -15,7 +15,13 @@ defmodule MultiNodeSyncTest do
   end
 
   setup do
-    :ok = TestFramework.new_nodes([{:node1, 2}, {:node2, 3}, {:node3, 4}, {:node4, 5}])
+    port1 = Utils.find_port(2)
+    port2 = Utils.find_port(port1 + 1)
+    port3 = Utils.find_port(port2 + 1)
+    port4 = Utils.find_port(port3 + 1)
+
+    :ok =
+      TestFramework.new_nodes([{:node1, port1}, {:node2, port2}, {:node3, port3}, {:node4, port4}])
 
     Utils.sync_nodes(:node1, :node2)
     Utils.sync_nodes(:node2, :node3)


### PR DESCRIPTION
This is a PR **into** branch GH-602.

This should hopefully fix stability problems with testframework. I managed to make tests run faster and reliably on my laptop.

Changes:
- a little bit less checks (maybe we should revert this, but I think it's ok)
- compare only top hashes instead of full blocks
- concurent node starting
- force kill nodes instead of gracefull stop
- harcode port numbers instead of detecting open ports
- properly checking if transaction is in pool (we have sometimes mined transactions in pool, becouse pool is synced and different nodes might get new blocks at different time)
- NEW - use mock miner (MIX_ENV=test)

TODO (as part of different PR):
- checking if transactions get mined
- consider lowering number of nodes to 3
- reuse nodes (reset nodes between tests in some way)