### PR TITLE
[GH-716] moved environment variable reading from config to code

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -31,7 +31,8 @@ erl_crash.dump
 *.iml
 
 # Ignore priv dir
-apps/aecore/priv/
+apps/aecore/priv/*
+!apps/aecore/priv/genesis/
 
 # Ignore Cuckoo c_src
 apps/aecore/src/cuckoo/c_src/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,11 @@
-FROM ubuntu:16.04
+FROM ubuntu:18.04
 
 # DISCLAIMER: this is not optimized and configured well, use carefully
 
 RUN adduser --disabled-password --gecos "" elixir
 
 RUN apt-get -qq update
-RUN apt-get install -y curl locales git build-essential autoconf autogen libtool libgmp3-dev openssl
+RUN apt-get install -y curl locales git build-essential autoconf autogen libtool libgmp3-dev libssl1.0.0
 
 RUN LIBSODIUM_VERSION=1.0.16 \
     && LIBSODIUM_DOWNLOAD_URL="https://github.com/jedisct1/libsodium/releases/download/${LIBSODIUM_VERSION}/libsodium-${LIBSODIUM_VERSION}.tar.gz" \
@@ -24,7 +24,7 @@ ENV LC_ALL en_US.UTF-8
 RUN curl https://packages.erlang-solutions.com/erlang-solutions_1.0_all.deb -o erlang-solutions_1.0_all.deb
 RUN dpkg -i erlang-solutions_1.0_all.deb
 RUN apt-get update
-RUN apt-get install -y esl-erlang=1:20.3 elixir=1.6.4-1
+RUN apt-get install -y esl-erlang=1:20.3 elixir=1.6.6-1
 
 # install rust dependency for rocksdb persistence
 USER elixir

--- a/apps/aecore/config/config.exs
+++ b/apps/aecore/config/config.exs
@@ -3,42 +3,6 @@ use Mix.Config
 %{year: year, month: month, day: day} = DateTime.utc_now()
 time = "#{year}-#{month}-#{day}_"
 
-persistence_path =
-  case System.get_env("PERSISTENCE_PATH") do
-    nil -> "/rox_db/"
-    env -> env
-  end
-
-sign_keys_pass =
-  case System.get_env("SIGN_KEYS_PASS") do
-    nil -> <<"secret">>
-    env -> env
-  end
-
-sign_keys_path =
-  case System.get_env("SIGN_KEYS_PATH") do
-    nil -> "/signkeys"
-    env -> env
-  end
-
-peer_keys_pass =
-  case System.get_env("PEER_KEYS_PASS") do
-    nil -> <<"secret">>
-    env -> env
-  end
-
-peerkeys_path =
-  case System.get_env("PEER_KEYS_PATH") do
-    nil -> "/peerkeys"
-    env -> env
-  end
-
-accounts_path =
-  case System.get_env("ACCOUNTS_PATH") do
-    nil -> "/genesis/"
-    env -> env
-  end
-
 config :aecore, :spend_tx, version: 1
 
 config :aecore, :sign_keys, pubkey_size: 32
@@ -47,24 +11,11 @@ config :aecore, :signed_tx, sign_max_size: 72
 
 config :aecore, :oracle_response_tx, query_id: 64
 
-config :aecore, :peer_keys, path: Path.absname(peerkeys_path)
-
 config :aecore, :naming,
   max_label_length: 63,
   max_name_length: 253
 
-config :aecore, :sign_keys,
-  pass: sign_keys_pass,
-  path: Path.absname(sign_keys_path)
-
-config :aecore, :peer_keys,
-  pass: peer_keys_pass,
-  path: Path.absname(peerkeys_path)
-
-config :aecore, :account_path, path: Path.absname(accounts_path)
-
 config :aecore, :persistence,
-  path: persistence_path |> Path.absname() |> Path.join("//"),
   number_of_blocks_in_memory: 100,
   write_options: [sync: true, disable_wal: false]
 

--- a/apps/aecore/config/dev.exs
+++ b/apps/aecore/config/dev.exs
@@ -1,44 +1,10 @@
 use Mix.Config
 
-persistence_path =
-  case System.get_env("PERSISTENCE_PATH") do
-    nil -> "/rox_db/"
-    env -> env
-  end
+config :aecore, :persistence, write_options: [sync: true, disable_wal: false]
 
-config :aecore, :persistence,
-  path: Path.absname(persistence_path),
-  write_options: [sync: true, disable_wal: false]
+config :aecore, :pow, params: {"./lean16", "-t 5", 16}
 
-accounts_path =
-  case System.get_env("ACCOUNTS_PATH") do
-    nil -> "/genesis/"
-    env -> env
-  end
-
-config :aecore, :account_path, path: Path.absname(accounts_path)
-
-new_candidate_nonce_count =
-  case System.get_env("NEW_CANDIDATE_NONCE_COUNT") do
-    nil -> 10
-    env -> env
-  end
-
-config :aecore, :pow,
-  new_candidate_nonce_count: new_candidate_nonce_count,
-  bin_dir: "/cuckoo/bin",
-  params: {"./lean16", "-t 5", 16},
-  max_target_change: 1
-
-sync_port =
-  case System.get_env("SYNC_PORT") do
-    nil -> 3015
-    env -> String.to_integer(env)
-  end
-
-config :aecore, :peers,
-  ranch_acceptors: 10,
-  sync_port: sync_port
+config :aecore, :peers, ranch_acceptors: 10
 
 config :aecore, :miner, resumed_by_default: false
 

--- a/apps/aecore/config/dev_build.exs
+++ b/apps/aecore/config/dev_build.exs
@@ -5,20 +5,12 @@ import_config "dev.exs"
 %{year: year, month: month, day: day} = DateTime.utc_now()
 time = "#{year}-#{month}-#{day}_"
 
-config :aecore, :persistence, path: Path.absname("_build/dev_build/priv/rox_db")
-
-config :aecore, :peer_keys, path: Path.absname("_build/dev_build/priv/peerkeys")
-
 config :logger,
   compile_time_purge_level: :info,
   backends: [:console, {LoggerFileBackend, :info}, {LoggerFileBackend, :error}]
 
-config :logger, :info,
-  path: Path.absname("_build/dev_build/logs/#{time}info.log"),
-  level: :info
+config :logger, :info, level: :info
 
-config :logger, :error,
-  path: Path.absname("_build/dev_build/logs/#{time}error.log"),
-  level: :error
+config :logger, :error, level: :error
 
 config :aecore, :miner, resumed_by_default: false

--- a/apps/aecore/config/prod.exs
+++ b/apps/aecore/config/prod.exs
@@ -2,9 +2,7 @@ use Mix.Config
 
 import_config "dev.exs"
 
-config :aecore, :pow,
-  params: {"./mean28s-generic", "-t 5", 28},
-  max_target_change: 1
+config :aecore, :pow, params: {"./mean28s-generic", "-t 5", 28}
 
 config :aecore, :miner, resumed_by_default: true
 

--- a/apps/aecore/config/test.exs
+++ b/apps/aecore/config/test.exs
@@ -2,8 +2,6 @@ use Mix.Config
 
 import_config "dev.exs"
 
-config :aecore, :pow, max_target_change: 0
-
 config :aecore, :tx_data, minimum_fee: 1
 
 config :aecore, :pow_module, Aecore.Pow.Mock

--- a/apps/aecore/lib/aecore/chain/genesis.ex
+++ b/apps/aecore/lib/aecore/chain/genesis.ex
@@ -7,10 +7,9 @@ defmodule Aecore.Chain.Genesis do
   alias Aecore.Chain.{Block, Chainstate, Header}
   alias Aecore.Governance.GovernanceConstants, as: Governance
   alias Aecore.Governance.GenesisConstants, as: GenesisConstants
+  alias Aeutil.Environment
 
   require Logger
-
-  @dir Application.get_env(:aecore, :account_path)[:path]
 
   @spec hash() :: binary()
   def hash do
@@ -61,7 +60,10 @@ defmodule Aecore.Chain.Genesis do
   @spec read_presets() :: {:ok, binary()} | {:error, reason :: atom()}
   def read_presets do
     preset_accounts_file =
-      Path.join([Application.app_dir(:aecore, "priv"), @dir, "accounts.json"])
+      Path.join([
+        Environment.get_env_or_core_priv_dir("ACCOUNTS_PATH", "genesis"),
+        "accounts.json"
+      ])
 
     case File.read(preset_accounts_file) do
       {:ok, _} = file -> file

--- a/apps/aecore/lib/aecore/keys/keys.ex
+++ b/apps/aecore/lib/aecore/keys/keys.ex
@@ -4,8 +4,9 @@ defmodule Aecore.Keys do
   Keys are created on the first run of the project and saved in their respective directories.
   """
 
-  alias Aeutil.Bits
   alias Aecore.Chain.Identifier
+  alias Aeutil.Environment
+  alias Aeutil.Bits
 
   @typedoc "Defines what type of keypair we could have"
   @type keypair_type :: :sign | :peer
@@ -205,26 +206,11 @@ defmodule Aecore.Keys do
     Bits.decode58(payload)
   end
 
-  defp pwd(:sign) do
-    {:ok, opts} = sign_keys_opts()
-    opts[:pass]
-  end
+  defp pwd(:sign), do: Environment.get_env_or_default("SIGN_KEYS_PASS", <<"secret">>)
 
-  defp pwd(:peer) do
-    {:ok, opts} = peer_keys_opts()
-    opts[:pass]
-  end
+  defp pwd(:peer), do: Environment.get_env_or_default("PEER_KEYS_PASS", <<"secret">>)
 
-  defp dir(:sign) do
-    {:ok, opts} = sign_keys_opts()
-    Application.app_dir(:aecore, "priv") <> opts[:path]
-  end
+  defp dir(:sign), do: Environment.get_env_or_core_priv_dir("PEER_KEYS_PATH", "signkeys")
 
-  defp dir(:peer) do
-    {:ok, opts} = peer_keys_opts()
-    Application.app_dir(:aecore, "priv") <> opts[:path]
-  end
-
-  defp sign_keys_opts, do: Application.fetch_env(:aecore, :sign_keys)
-  defp peer_keys_opts, do: Application.fetch_env(:aecore, :peer_keys)
+  defp dir(:peer), do: Environment.get_env_or_core_priv_dir("SIGN_KEYS_PATH", "peerkeys")
 end

--- a/apps/aecore/lib/aecore/miner/worker.ex
+++ b/apps/aecore/lib/aecore/miner/worker.ex
@@ -16,6 +16,7 @@ defmodule Aecore.Miner.Worker do
   alias Aecore.Pow.Pow
   alias Aecore.Tx.Pool.Worker, as: Pool
   alias Aecore.Tx.{DataTx, SignedTx}
+  alias Aeutil.Environment
 
   require Logger
 
@@ -163,7 +164,7 @@ defmodule Aecore.Miner.Worker do
     nonce = next_nonce(cblock.header.nonce)
 
     cblock =
-      case rem(nonce, Application.get_env(:aecore, :pow)[:new_candidate_nonce_count]) do
+      case rem(nonce, new_candidate_nonce_count()) do
         0 -> candidate()
         _ -> cblock
       end
@@ -357,4 +358,7 @@ defmodule Aecore.Miner.Worker do
 
   def next_nonce(@mersenne_prime), do: 0
   def next_nonce(nonce), do: nonce + 1
+
+  def new_candidate_nonce_count,
+    do: Environment.get_env_or_default("NEW_CANDIDATE_NONCE_COUNT", 100)
 end

--- a/apps/aecore/lib/aecore/peers/worker/supervisor.ex
+++ b/apps/aecore/lib/aecore/peers/worker/supervisor.ex
@@ -10,6 +10,7 @@ defmodule Aecore.Peers.Worker.Supervisor do
   alias Aecore.Peers.PeerConnection
   alias Aecore.Peers.Worker.PeerConnectionSupervisor
   alias Aecore.Keys
+  alias Aeutil.Environment
 
   def start_link(_args) do
     Supervisor.start_link(__MODULE__, :ok)
@@ -39,11 +40,7 @@ defmodule Aecore.Peers.Worker.Supervisor do
     Supervisor.init(children, strategy: :one_for_all)
   end
 
-  def sync_port do
-    Application.get_env(:aecore, :peers)[:sync_port]
-  end
+  def sync_port, do: String.to_integer(Environment.get_env_or_default("SYNC_PORT", "3015"))
 
-  def num_of_acceptors do
-    Application.get_env(:aecore, :peers)[:ranch_acceptors]
-  end
+  def num_of_acceptors, do: Application.get_env(:aecore, :peers)[:ranch_acceptors]
 end

--- a/apps/aecore/lib/aecore/persistence/worker.ex
+++ b/apps/aecore/lib/aecore/persistence/worker.ex
@@ -8,6 +8,7 @@ defmodule Aecore.Persistence.Worker do
 
   alias Aecore.Chain.{Block, Header, Target}
   alias Aecore.Persistence.Supplier
+  alias Aeutil.Environment
   alias Aeutil.Scientific
   alias Rox.Batch
 
@@ -417,8 +418,7 @@ defmodule Aecore.Persistence.Worker do
     {:reply, handler, state}
   end
 
-  defp persistence_path,
-    do: Application.app_dir(:aecore, "priv") <> Application.get_env(:aecore, :persistence)[:path]
+  def persistence_path, do: Environment.get_env_or_core_priv_dir("PERSISTENCE_PATH", "rox_db")
 
   defp build_state(
          db_refs,

--- a/apps/aecore/lib/aecore/pow/cuckoo.ex
+++ b/apps/aecore/lib/aecore/pow/cuckoo.ex
@@ -13,7 +13,7 @@ defmodule Aecore.Pow.Cuckoo do
 
   alias Aecore.Chain.Header
   alias Aecore.Pow.Hashcash
-  alias Aeutil.Hash
+  alias Aeutil.{Environment, Hash}
 
   @behaviour Aecore.Pow.PowAlgorithm
 
@@ -80,8 +80,7 @@ defmodule Aecore.Pow.Cuckoo do
   defp command_options(:generate), do: default_command_options()
 
   defp default_command_options do
-    full_bin_dir =
-      Application.app_dir(:aecore, "priv") <> Application.get_env(:aecore, :pow)[:bin_dir]
+    full_bin_dir = Environment.core_priv_dir("cuckoo/bin")
 
     [
       {:stdout, self()},

--- a/apps/aecore/lib/aecore/pow/pow.ex
+++ b/apps/aecore/lib/aecore/pow/pow.ex
@@ -1,6 +1,6 @@
 defmodule Aecore.Pow.Pow do
   @moduledoc """
-  A meta Proof of work alorithm that invokes proper allgorithm for current environment
+  A meta Proof of work alorithm that invokes proper allgorithm for current environment.ex
   """
 
   alias Aecore.Chain.Header

--- a/apps/aecore/lib/aecore/pow/pow.ex
+++ b/apps/aecore/lib/aecore/pow/pow.ex
@@ -1,6 +1,6 @@
 defmodule Aecore.Pow.Pow do
   @moduledoc """
-  A meta Proof of work alorithm that invokes proper allgorithm for current environment.ex
+  An abstraction layer for Proof of Work schemes that invokes the chosen algorithm based on the current environment variables
   """
 
   alias Aecore.Chain.Header
@@ -8,7 +8,7 @@ defmodule Aecore.Pow.Pow do
   @behaviour Aecore.Pow.PowAlgorithm
 
   @doc """
-  Calls verify of apropriate module
+  Calls verify of appropriate module
   """
   @spec verify(Header.t()) :: boolean()
   def verify(%Header{} = header) do
@@ -16,7 +16,7 @@ defmodule Aecore.Pow.Pow do
   end
 
   @doc """
-  Calls generate of apropriate module
+  Calls generate of appropriate module
   """
   @spec generate(Header.t()) :: {:ok, Header.t()}
   def generate(%Header{} = header) do

--- a/apps/aecore/test/aecore_channels_test.exs
+++ b/apps/aecore/test/aecore_channels_test.exs
@@ -107,7 +107,7 @@ defmodule AecoreChannelTest do
     perform_withdraw(id, 50, 5, 2, &call_s1/1, ctx.pk1, ctx.sk1, &call_s2/1, ctx.pk2, ctx.sk2)
     assert_offchain_state(id, 100, 150, 2)
 
-    perform_withdraw(id, 50, 5, 2, &call_s2/1, ctx.pk2, ctx.sk2, &call_s1/1, ctx.pk1, ctx.sk1)
+    perform_withdraw(id, 50, 5, 1, &call_s2/1, ctx.pk2, ctx.sk2, &call_s1/1, ctx.pk1, ctx.sk1)
     assert_offchain_state(id, 100, 100, 3)
 
     {:ok, close_tx} = call_s1({:close, id, {5, 5}, 3, ctx.sk1})
@@ -137,7 +137,7 @@ defmodule AecoreChannelTest do
     perform_deposit(id, 20, 5, 2, &call_s1/1, ctx.pk1, ctx.sk1, &call_s2/1, ctx.pk2, ctx.sk2)
     assert_offchain_state(id, 170, 150, 2)
 
-    perform_deposit(id, 20, 5, 2, &call_s2/1, ctx.pk2, ctx.sk2, &call_s1/1, ctx.pk1, ctx.sk1)
+    perform_deposit(id, 20, 5, 1, &call_s2/1, ctx.pk2, ctx.sk2, &call_s1/1, ctx.pk1, ctx.sk1)
     assert_offchain_state(id, 170, 170, 3)
 
     {:ok, close_tx} = call_s1({:close, id, {5, 5}, 3, ctx.sk1})

--- a/apps/aecore/test/aecore_pow_cuckoo_test.exs
+++ b/apps/aecore/test/aecore_pow_cuckoo_test.exs
@@ -10,6 +10,15 @@ defmodule AecoreCuckooTest do
   alias Aecore.Pow.Cuckoo
   alias Aecore.Chain.{Block, Header}
 
+  setup do
+    orig_params = Application.get_env(:aecore, :pow)
+    Application.put_env(:aecore, :pow, params: {"./lean16", "-t 1", 16})
+
+    on_exit(fn ->
+      Application.put_env(:aecore, :pow, orig_params)
+    end)
+  end
+
   @tag timeout: 60_000
   @tag :cuckoo
   test "Generate solution with a winning nonce and high target threshold" do

--- a/apps/aecore/test/aecore_txs_pool_test.exs
+++ b/apps/aecore/test/aecore_txs_pool_test.exs
@@ -7,6 +7,7 @@ defmodule AecoreTxsPoolTest do
   alias Aecore.Tx.Pool.Worker, as: Pool
   alias Aecore.Miner.Worker, as: Miner
   alias Aecore.Chain.Worker, as: Chain
+  alias Aecore.Persistence.Worker, as: Persistence
   alias Aecore.Account.Tx.SpendTx
   alias Aecore.Tx.DataTx
   alias Aecore.Keys
@@ -14,7 +15,7 @@ defmodule AecoreTxsPoolTest do
 
   setup do
     Code.require_file("test_utils.ex", "./test")
-    path = Application.get_env(:aecore, :persistence)[:path]
+    path = Persistence.persistence_path()
 
     if File.exists?(path) do
       File.rm_rf(path)

--- a/apps/aecore/test/aecore_validation_test.exs
+++ b/apps/aecore/test/aecore_validation_test.exs
@@ -10,6 +10,7 @@ defmodule AecoreValidationTest do
   alias Aecore.Chain.{Block, Header, Genesis}
   alias Aecore.Chain.Worker, as: Chain
   alias Aecore.Miner.Worker, as: Miner
+  alias Aecore.Persistence.Worker, as: Persistence
   alias Aecore.Keys
   alias Aecore.Account.Account
   alias Aecore.Governance.GovernanceConstants
@@ -18,7 +19,7 @@ defmodule AecoreValidationTest do
     Code.require_file("test_utils.ex", "./test")
     TestUtils.clean_blockchain()
 
-    path = Application.get_env(:aecore, :persistence)[:path]
+    path = Persistence.persistence_path()
 
     if File.exists?(path) do
       File.rm_rf(path)

--- a/apps/aehttpserver/config/config.exs
+++ b/apps/aehttpserver/config/config.exs
@@ -6,7 +6,8 @@ config :aehttpserver, Aehttpserver.Web.Endpoint,
   url: [host: "localhost"],
   secret_key_base: "iC7edxvq+oLqfi0E3jpHq9hq0PLu+n0xeJkjxRwPO+klI8fR8s/5n+Y30asPxlYo",
   render_errors: [view: Aehttpserver.Web.ErrorView, accepts: ~w(html json)],
-  pubsub: [name: Aehttpserver.PubSub, adapter: Phoenix.PubSub.PG2]
+  pubsub: [name: Aehttpserver.PubSub, adapter: Phoenix.PubSub.PG2],
+  load_from_system_env: true
 
 config :logger, :console,
   format: "$time $metadata[$level] $message\n",

--- a/apps/aehttpserver/config/dev.exs
+++ b/apps/aehttpserver/config/dev.exs
@@ -1,13 +1,6 @@
 use Mix.Config
 
-port =
-  case System.get_env("PORT") do
-    nil -> 4000
-    env -> env
-  end
-
 config :aehttpserver, Aehttpserver.Web.Endpoint,
-  http: [port: port],
   debug_errors: true,
   check_origin: false,
   watchers: []

--- a/apps/aehttpserver/config/prod.exs
+++ b/apps/aehttpserver/config/prod.exs
@@ -1,8 +1,6 @@
 use Mix.Config
 
-config :aehttpserver, Aehttpserver.Web.Endpoint,
-  on_init: {Aehttpserver.Web.Endpoint, :load_from_system_env, []},
-  url: [host: "localhost", port: 4000]
+config :aehttpserver, Aehttpserver.Web.Endpoint, url: [host: "localhost"]
 
 config :logger, level: :info
 

--- a/apps/aehttpserver/config/test.exs
+++ b/apps/aehttpserver/config/test.exs
@@ -1,14 +1,6 @@
 use Mix.Config
 
-port =
-  case System.get_env("PORT") do
-    nil -> 4000
-    env -> env
-  end
-
-config :aehttpserver, Aehttpserver.Web.Endpoint,
-  http: [port: port],
-  server: true
+config :aehttpserver, Aehttpserver.Web.Endpoint, server: true
 
 # Print only warnings and errors during test
 config :logger, level: :warn

--- a/apps/aehttpserver/lib/aehttpserver/web/controllers/peers_controller.ex
+++ b/apps/aehttpserver/lib/aehttpserver/web/controllers/peers_controller.ex
@@ -4,9 +4,10 @@ defmodule Aehttpserver.Web.PeersController do
   alias Aecore.Peers.Worker, as: Peers
   alias Aecore.Account.Account
   alias Aecore.Keys
+  alias Aeutil.Environment
 
   def info(conn, _params) do
-    sync_port = Application.get_env(:aecore, :peers)[:sync_port]
+    sync_port = String.to_integer(Environment.get_env_or_default("SYNC_PORT", "3015"))
 
     peer_pubkey =
       :peer

--- a/apps/aehttpserver/lib/aehttpserver/web/endpoint.ex
+++ b/apps/aehttpserver/lib/aehttpserver/web/endpoint.ex
@@ -1,6 +1,8 @@
 defmodule Aehttpserver.Web.Endpoint do
   use Phoenix.Endpoint, otp_app: :aehttpserver
 
+  alias Aeutil.Environment
+
   socket("/socket", Aehttpserver.Web.UserSocket)
 
   plug(Plug.Logger, log: :debug)
@@ -21,9 +23,12 @@ defmodule Aehttpserver.Web.Endpoint do
   It receives the endpoint configuration from the config files
   and must return the updated configuration.
   """
-  def load_from_system_env(config) do
-    port = System.get_env("PORT") || raise "expected the PORT environment variable to be set"
-
-    {:ok, Keyword.put(config, :http, [:inet6, port: port])}
+  def init(_key, config) do
+    if config[:load_from_system_env] do
+      port = String.to_integer(Environment.get_env_or_default("PORT", "4000"))
+      {:ok, Keyword.put(config, :http, [:inet6, port: port])}
+    else
+      {:ok, config}
+    end
   end
 end

--- a/apps/aetestframework/lib/worker.ex
+++ b/apps/aetestframework/lib/worker.ex
@@ -160,10 +160,9 @@ defmodule Aetestframework.Worker do
 
     Enum.each(state, fn {_node, %{port_id: port_id, node_port: port}} ->
       Port.close(port_id)
-      path_to_priv_dir = project_dir() <> Application.app_dir(:aecore, "priv")
-      File.rm_rf(path_to_priv_dir <> "test_signkeys_#{port}")
-      File.rm_rf(path_to_priv_dir <> "test_peerkeys_#{port}")
-      File.rm_rf(path_to_priv_dir <> "test_rox_db_#{port}")
+      File.rm_rf(Path.join([Application.app_dir(:aecore, "priv"), "test_signkeys_#{port}"]))
+      File.rm_rf(Path.join([Application.app_dir(:aecore, "priv"), "test_peerkeys_#{port}"]))
+      File.rm_rf(Path.join([Application.app_dir(:aecore, "priv"), "test_rox_db_#{port}"]))
     end)
 
     {:reply, :ok, %{}}

--- a/apps/aeutil/lib/environment.ex
+++ b/apps/aeutil/lib/environment.ex
@@ -1,0 +1,19 @@
+defmodule Aeutil.Environment do
+  @moduledoc """
+  utility for providing environment specific variables
+  """
+
+  def core_priv_dir, do: Application.app_dir(:aecore, "priv")
+
+  def core_priv_dir(dir), do: Path.join([core_priv_dir(), dir])
+
+  def get_env_or_default(environment_variable, default) do
+    case System.get_env(environment_variable) do
+      nil -> default
+      env -> env
+    end
+  end
+
+  def get_env_or_core_priv_dir(environment_variable, dir),
+    do: get_env_or_default(environment_variable, core_priv_dir(dir))
+end


### PR DESCRIPTION
This was needed to start the release with a different SYNC_PORT than epoch.

resolves #716