### PR TITLE
[GH-722] Spellcheck our entire code base

### DIFF
--- a/apps/aecore/lib/aecore/account/account.ex
+++ b/apps/aecore/lib/aecore/account/account.ex
@@ -42,7 +42,7 @@ defmodule Aecore.Account.Account do
   Definition of the Account structure
 
   # Parameters
-  - balance: the acccount balance
+  - balance: the account balance
   - nonce: an integer which is updated (always increased) whenever an outgoing transaction is made by the account
   - id: the account itself
   """

--- a/apps/aecore/lib/aecore/chain/block_validation.ex
+++ b/apps/aecore/lib/aecore/chain/block_validation.ex
@@ -103,7 +103,7 @@ defmodule Aecore.Chain.BlockValidation do
         {:error, "#{__MODULE__}: Invalid header time"}
 
       !is_target_met?(header) ->
-        {:error, "#{__MODULE__}: Header hash doesnt meet the target"}
+        {:error, "#{__MODULE__}: Header hash doesn't meet the target"}
 
       true ->
         :ok

--- a/apps/aecore/lib/aecore/chain/worker.ex
+++ b/apps/aecore/lib/aecore/chain/worker.ex
@@ -352,9 +352,9 @@ defmodule Aecore.Chain.Worker do
     Enum.each(txs, fn tx -> Pool.remove_transaction(tx) end)
     new_block_hash = Header.hash(header)
 
-    # refs_list is generated so it contains n-th prev blocks for n-s beeing a power of two.
+    # refs_list is generated so it contains n-th prev blocks for n-s being a power of two.
     # So for chain A<-B<-C<-D<-E<-F<-G<-H. H refs will be [G,F,D,A].
-    # This allows for log n findning of block with a given height.
+    # This allows for log n finding of block with a given height.
 
     new_refs = refs(@max_refs, blocks_data_map, prev_hash)
 
@@ -382,7 +382,7 @@ defmodule Aecore.Chain.Worker do
 
     if top_height < height do
       Persistence.batch_write(%{
-        # Transfrom from chain state
+        # Transform from chain state
         :chain_state => %{
           new_block_hash =>
             transform_chainstate(:from_chainstate, {:ok, Map.from_struct(new_chain_state)})
@@ -578,11 +578,11 @@ defmodule Aecore.Chain.Worker do
   end
 
   # get_nth_prev_hash - traverses block_data_map using the refs.
-  # Becouse refs contain hashes of 1,2,4,8,16,... prev blocks we can do it fast.
+  # Because refs contain hashes of 1,2,4,8,16,... prev blocks we can do it fast.
   # Lets look at the height difference as a binary representation.
   # Eg. Lets say we want to go 10110 blocks back in the tree.
   # Instead of using prev_block 10110 times we can go back by 2 blocks then by 4 and by 16.
-  # We can go back by such numbers of blocks becouse we have the refs.
+  # We can go back by such numbers of blocks because we have the refs.
   # This way we did 3 operations instead of 22. In general we do O(log n) operations
   # to go back by n blocks.
   defp get_nth_prev_hash(n, begin_hash, blocks_data_map) do

--- a/apps/aecore/lib/aecore/channel/channel_off_chain_tx.ex
+++ b/apps/aecore/lib/aecore/channel/channel_off_chain_tx.ex
@@ -232,7 +232,7 @@ defmodule Aecore.Channel.ChannelOffChainTx do
         ExRLP.decode(binary)
       rescue
         e ->
-          {:error, "#{__MODULE__}: rlp_decode: IIllegal serialization: #{Exception.message(e)}"}
+          {:error, "#{__MODULE__}: rlp_decode: Illegal serialization: #{Exception.message(e)}"}
       end
 
     {:ok, signedtx_tag} = TypeToTag.type_to_tag(SignedTx)
@@ -251,10 +251,10 @@ defmodule Aecore.Channel.ChannelOffChainTx do
         end
 
       [^signedtx_tag_bin, ^signedtx_ver_bin | _] ->
-        {:error, "#{__MODULE__}: Invalid signedtx serialization"}
+        {:error, "#{__MODULE__}: Invalid SignedTx serialization"}
 
       [^signedtx_tag_bin | _] ->
-        {:error, "#{__MODULE__}: Unknown signedtx version"}
+        {:error, "#{__MODULE__}: Unknown SignedTx version"}
 
       list when is_list(list) ->
         {:error, "#{__MODULE__}: Invalid tag"}

--- a/apps/aecore/lib/aecore/channel/channel_off_chain_update.ex
+++ b/apps/aecore/lib/aecore/channel/channel_off_chain_update.ex
@@ -122,7 +122,7 @@ defmodule Aecore.Channel.ChannelOffChainUpdate do
     )
   end
 
-  # Function passed to Enum.reduce. Aplies the given update to the chainstate.
+  # Function passed to Enum.reduce. Applies the given update to the chainstate.
   @spec apply_single_update_to_chainstate(
           update_types(),
           {:ok, Chainstate.t() | nil},
@@ -139,7 +139,7 @@ defmodule Aecore.Channel.ChannelOffChainUpdate do
   end
 
   @doc """
-  Updates the offchain chainstate acording to the specified update.
+  Updates the offchain chainstate according to the specified update.
   """
   @spec update_offchain_chainstate(Chainstate.t() | nil, update_types()) ::
           {:ok, Chainstate.t()} | error()

--- a/apps/aecore/lib/aecore/channel/channel_state_peer.ex
+++ b/apps/aecore/lib/aecore/channel/channel_state_peer.ex
@@ -16,7 +16,7 @@ defmodule Aecore.Channel.ChannelStatePeer do
 
   alias Aecore.Channel.Tx.{
     ChannelCreateTx,
-    ChannelCloseMutalTx,
+    ChannelCloseMutualTx,
     ChannelCloseSoloTx,
     ChannelSlashTx,
     ChannelSettleTx,
@@ -165,7 +165,7 @@ defmodule Aecore.Channel.ChannelStatePeer do
   end
 
   @doc """
-  Creates a channel from a list of mutually signed tx. The first tx in the list must be ChannelCreateTX. All the tx and updates are verified for corectness along the way.
+  Creates a channel from a list of mutually signed tx. The first tx in the list must be ChannelCreateTx. All the tx and updates are verified for correctness along the way.
   """
   @spec from_signed_tx_list(
           list(ChannelTransaction.signed_tx()),
@@ -229,7 +229,7 @@ defmodule Aecore.Channel.ChannelStatePeer do
   end
 
   @doc """
-    Calculates the state hash of the offchain chainstate after aplying the transaction.
+    Calculates the state hash of the offchain chainstate after applying the transaction.
     Only basic verification is done.
   """
   @spec calculate_next_state_hash_for_new_tx(
@@ -328,7 +328,7 @@ defmodule Aecore.Channel.ChannelStatePeer do
 
     case calculate_next_state_hash_for_new_tx(unvalidated_unsigned_tx, peer_state) do
       {:ok, state_hash} ->
-        # validation was successfull
+        # validation was successful
         unvalidated_unsigned_tx
         # ties the tx to the updated state
         |> ChannelTransaction.set_state_hash(state_hash)
@@ -845,7 +845,7 @@ defmodule Aecore.Channel.ChannelStatePeer do
   end
 
   @doc """
-  Creates mutal close tx for open channel. This blocks any new transfers on channel. Returns: altered ChannelStatePeer and ChannelCloseMutalTx
+  Creates mutual close tx for open channel. This blocks any new transfers on channel. Returns: altered ChannelStatePeer and ChannelCloseMutualTx
   """
   @spec close(
           ChannelStatePeer.t(),
@@ -883,7 +883,7 @@ defmodule Aecore.Channel.ChannelStatePeer do
       true ->
         close_tx =
           DataTx.init(
-            ChannelCloseMutalTx,
+            ChannelCloseMutualTx,
             %{
               channel_id: channel_id,
               initiator_amount: initiator_amount - fee_initiator,
@@ -906,7 +906,7 @@ defmodule Aecore.Channel.ChannelStatePeer do
   end
 
   @doc """
-  Handles incoming channel close tx. If our highest state matches the incoming signs the tx and blocks any new transfers. Returns altered ChannelStatePeer and signed ChannelCloseMutalTx
+  Handles incoming channel close tx. If our highest state matches the incoming signs the tx and blocks any new transfers. Returns altered ChannelStatePeer and signed ChannelCloseMutualTx
   """
   @spec receive_close_tx(
           ChannelStatePeer.t(),
@@ -923,7 +923,7 @@ defmodule Aecore.Channel.ChannelStatePeer do
         } = peer_state,
         %SignedTx{
           data: %DataTx{
-            payload: %ChannelCloseMutalTx{
+            payload: %ChannelCloseMutualTx{
               channel_id: tx_id,
               initiator_amount: tx_initiator_amount,
               responder_amount: tx_responder_amount
@@ -966,7 +966,7 @@ defmodule Aecore.Channel.ChannelStatePeer do
   end
 
   @doc """
-  Changes the channel state to closed. Should only be called when a ChannelCloseMutalTx is mined.
+  Changes the channel state to closed. Should only be called when a ChannelCloseMutualTx is mined.
   """
   @spec closed(ChannelStatePeer.t()) :: ChannelStatePeer.t()
   def closed(%ChannelStatePeer{} = peer_state) do
@@ -1069,7 +1069,7 @@ defmodule Aecore.Channel.ChannelStatePeer do
 
     # We cannot rely on the sequence as SlashTx/SoloTx may not contain a payload.
     # Because SlashTx/SoloTx was mined the state hash present here must have been verified onchain
-    # If it was verfied onchain then we needed to sign it - In conclusion we can rely on the state hash
+    # If it was verified onchain then we needed to sign it - In conclusion we can rely on the state hash
     if slash_hash != ChannelTransaction.unsigned_payload(most_recent_tx).state_hash do
       slash(peer_state, fee, nonce, privkey)
     else

--- a/apps/aecore/lib/aecore/channel/tx/channel_close_mutual_tx.ex
+++ b/apps/aecore/lib/aecore/channel/tx/channel_close_mutual_tx.ex
@@ -1,4 +1,4 @@
-defmodule Aecore.Channel.Tx.ChannelCloseMutalTx do
+defmodule Aecore.Channel.Tx.ChannelCloseMutualTx do
   @moduledoc """
   Module defining the ChannelCloseMutual transaction
   """
@@ -6,7 +6,7 @@ defmodule Aecore.Channel.Tx.ChannelCloseMutalTx do
   use Aecore.Tx.Transaction
 
   alias Aecore.Governance.GovernanceConstants
-  alias Aecore.Channel.Tx.ChannelCloseMutalTx
+  alias Aecore.Channel.Tx.ChannelCloseMutualTx
   alias Aecore.Tx.DataTx
   alias Aecore.Account.{Account, AccountStateTree}
   alias Aecore.Chain.Chainstate
@@ -31,14 +31,14 @@ defmodule Aecore.Channel.Tx.ChannelCloseMutalTx do
   @type tx_type_state() :: ChannelStateTree.t()
 
   @typedoc "Structure of the ChannelMutalClose Transaction type"
-  @type t :: %ChannelCloseMutalTx{
+  @type t :: %ChannelCloseMutualTx{
           channel_id: binary(),
           initiator_amount: non_neg_integer(),
           responder_amount: non_neg_integer()
         }
 
   @doc """
-  Definition of the ChannelCloseMutalTx structure
+  Definition of the ChannelCloseMutualTx structure
 
   # Parameters
   - channel_id: channel id
@@ -56,10 +56,10 @@ defmodule Aecore.Channel.Tx.ChannelCloseMutalTx do
   def chainstate_senders?(), do: true
 
   @doc """
-  ChannelCloseMutalTx senders are not passed with tx, but are supposed to be retrived from Chainstate. The senders have to be channel initiator and responder.
+  ChannelCloseMutualTx senders are not passed with tx, but are supposed to be retrieved from Chainstate. The senders have to be channel initiator and responder.
   """
-  @spec senders_from_chainstate(ChannelCloseMutalTx.t(), Chainstate.t()) :: list(binary())
-  def senders_from_chainstate(%ChannelCloseMutalTx{channel_id: channel_id}, chainstate) do
+  @spec senders_from_chainstate(ChannelCloseMutualTx.t(), Chainstate.t()) :: list(binary())
+  def senders_from_chainstate(%ChannelCloseMutualTx{channel_id: channel_id}, chainstate) do
     case ChannelStateTree.get(chainstate.channels, channel_id) do
       %ChannelStateOnChain{} = channel ->
         [channel.initiator_pubkey, channel.responder_pubkey]
@@ -69,13 +69,13 @@ defmodule Aecore.Channel.Tx.ChannelCloseMutalTx do
     end
   end
 
-  @spec init(payload()) :: ChannelCloseMutalTx.t()
+  @spec init(payload()) :: ChannelCloseMutualTx.t()
   def init(%{
         channel_id: channel_id,
         initiator_amount: initiator_amount,
         responder_amount: responder_amount
       }) do
-    %ChannelCloseMutalTx{
+    %ChannelCloseMutualTx{
       channel_id: channel_id,
       initiator_amount: initiator_amount,
       responder_amount: responder_amount
@@ -85,9 +85,9 @@ defmodule Aecore.Channel.Tx.ChannelCloseMutalTx do
   @doc """
   Validates the transaction without considering state
   """
-  @spec validate(ChannelCloseMutalTx.t(), DataTx.t()) :: :ok | {:error, reason()}
+  @spec validate(ChannelCloseMutualTx.t(), DataTx.t()) :: :ok | {:error, reason()}
   def validate(
-        %ChannelCloseMutalTx{
+        %ChannelCloseMutualTx{
           initiator_amount: initiator_amount,
           responder_amount: responder_amount
         },
@@ -115,7 +115,7 @@ defmodule Aecore.Channel.Tx.ChannelCloseMutalTx do
           Chainstate.accounts(),
           ChannelStateTree.t(),
           non_neg_integer(),
-          ChannelCloseMutalTx.t(),
+          ChannelCloseMutualTx.t(),
           DataTx.t(),
           Transaction.context()
         ) :: {:ok, {Chainstate.accounts(), ChannelStateTree.t()}}
@@ -123,7 +123,7 @@ defmodule Aecore.Channel.Tx.ChannelCloseMutalTx do
         accounts,
         channels,
         block_height,
-        %ChannelCloseMutalTx{
+        %ChannelCloseMutualTx{
           channel_id: channel_id,
           initiator_amount: initiator_amount,
           responder_amount: responder_amount
@@ -154,7 +154,7 @@ defmodule Aecore.Channel.Tx.ChannelCloseMutalTx do
           Chainstate.accounts(),
           ChannelStateTree.t(),
           non_neg_integer(),
-          ChannelCloseMutalTx.t(),
+          ChannelCloseMutualTx.t(),
           DataTx.t(),
           Transaction.context()
         ) :: :ok | {:error, reason()}
@@ -162,7 +162,7 @@ defmodule Aecore.Channel.Tx.ChannelCloseMutalTx do
         _accounts,
         channels,
         _block_height,
-        %ChannelCloseMutalTx{
+        %ChannelCloseMutualTx{
           channel_id: channel_id,
           initiator_amount: initiator_amount,
           responder_amount: responder_amount
@@ -211,8 +211,8 @@ defmodule Aecore.Channel.Tx.ChannelCloseMutalTx do
     fee >= GovernanceConstants.minimum_fee()
   end
 
-  @spec encode_to_list(ChannelCloseMutalTx.t(), DataTx.t()) :: list()
-  def encode_to_list(%ChannelCloseMutalTx{} = tx, %DataTx{} = datatx) do
+  @spec encode_to_list(ChannelCloseMutualTx.t(), DataTx.t()) :: list()
+  def encode_to_list(%ChannelCloseMutualTx{} = tx, %DataTx{} = datatx) do
     [
       :binary.encode_unsigned(@version),
       Identifier.create_encoded_to_binary(tx.channel_id, :channel),
@@ -242,7 +242,7 @@ defmodule Aecore.Channel.Tx.ChannelCloseMutalTx do
         }
 
         DataTx.init_binary(
-          ChannelCloseMutalTx,
+          ChannelCloseMutualTx,
           payload,
           [],
           :binary.decode_unsigned(fee),

--- a/apps/aecore/lib/aecore/channel/tx/channel_create_tx.ex
+++ b/apps/aecore/lib/aecore/channel/tx/channel_create_tx.ex
@@ -51,7 +51,7 @@ defmodule Aecore.Channel.Tx.ChannelCreateTx do
   - responder_amount: the amount that the second sender commits
   - locktime: number of blocks for dispute settling
   - state_hash: root hash of the initial offchain chainstate
-  - channel_reserve: minimal ammount of tokens held by the initiator or responder
+  - channel_reserve: minimal amount of tokens held by the initiator or responder
   """
   defstruct [
     :initiator_amount,

--- a/apps/aecore/lib/aecore/channel/updates/channel_create_update.ex
+++ b/apps/aecore/lib/aecore/channel/updates/channel_create_update.ex
@@ -1,7 +1,7 @@
 defmodule Aecore.Channel.Updates.ChannelCreateUpdate do
   @moduledoc """
-  State channel update which creates the offchain chainstate. This update can not be included in ChannelOffchainTx.
-  The creation of the initial chainstate is implemented as an update in order to increase readibility of the code and facilitate code reuse.
+  State channel update which creates the offchain chainstate. This update can not be included in ChannelOffChainTx.
+  The creation of the initial chainstate is implemented as an update in order to increase readability of the code and facilitate code reuse.
   """
 
   alias Aecore.Channel.Updates.ChannelCreateUpdate

--- a/apps/aecore/lib/aecore/channel/updates/channel_deposit_update.ex
+++ b/apps/aecore/lib/aecore/channel/updates/channel_deposit_update.ex
@@ -1,7 +1,7 @@
 defmodule Aecore.Channel.Updates.ChannelDepositUpdate do
   @moduledoc """
   State channel update implementing deposits in the state channel. This update can be included in ChannelOffchainTx.
-  This update is used by ChannelDepositTx for transfering onchain tokens to the state channel.
+  This update is used by ChannelDepositTx for transferring onchain tokens to the state channel.
   """
 
   alias Aecore.Channel.Updates.ChannelDepositUpdate

--- a/apps/aecore/lib/aecore/channel/updates/channel_transfer_update.ex
+++ b/apps/aecore/lib/aecore/channel/updates/channel_transfer_update.ex
@@ -1,7 +1,7 @@
 defmodule Aecore.Channel.Updates.ChannelTransferUpdate do
   @moduledoc """
-  State channel update implementing transfers in the state channel. This update can be included in ChannelOffchainTx.
-  This update allows for transfering tokens between peers in the state channel(later for transfers to offchain contract accounts)..
+  State channel update implementing transfers in the state channel. This update can be included in ChannelOffChainTx.
+  This update allows for transferring tokens between peers in the state channel(later for transfers to offchain contract accounts).
   """
 
   alias Aecore.Channel.Updates.ChannelTransferUpdate
@@ -32,7 +32,7 @@ defmodule Aecore.Channel.Updates.ChannelTransferUpdate do
   ## Parameters
   - from: the offchain account where the transfer originates
   - to: the offchain account which is the destination of the transfer
-  - amount: number of the tokens transfered between the peers
+  - amount: number of the tokens transferred between the peers
   """
   defstruct [:from, :to, :amount]
 

--- a/apps/aecore/lib/aecore/channel/updates/channel_withdraw_update.ex
+++ b/apps/aecore/lib/aecore/channel/updates/channel_withdraw_update.ex
@@ -1,7 +1,7 @@
 defmodule Aecore.Channel.Updates.ChannelWithdrawUpdate do
   @moduledoc """
-  State channel update implementing withdraws in the state channel. This update can be included in ChannelOffchainTx.
-  This update is used by ChannelWithdrawTx for transfering unlocking some of the state channel's tokens.
+  State channel update implementing withdraws in the state channel. This update can be included in ChannelOffChainTx.
+  This update is used by ChannelWithdrawTx for unlocking some of the state channel's tokens.
   """
 
   alias Aecore.Channel.Updates.ChannelWithdrawUpdate

--- a/apps/aecore/lib/aecore/channel/worker.ex
+++ b/apps/aecore/lib/aecore/channel/worker.ex
@@ -9,7 +9,7 @@ defmodule Aecore.Channel.Worker do
   alias Aecore.Channel.ChannelOffChainTx
 
   alias Aecore.Channel.Tx.{
-    ChannelCloseMutalTx,
+    ChannelCloseMutualTx,
     ChannelCloseSoloTx,
     ChannelSlashTx,
     ChannelSettleTx,
@@ -45,13 +45,12 @@ defmodule Aecore.Channel.Worker do
   @doc """
   Notifies the channel manager about a new mined tx
   """
-  # , ChannelWidhdrawTx, ChannelDepositTx]  do
   def new_tx_mined(%SignedTx{data: %DataTx{type: type}} = tx)
       when type in [ChannelCreateTx, ChannelWithdrawTx, ChannelDepositTx] do
     receive_confirmed_tx(tx)
   end
 
-  def new_tx_mined(%SignedTx{data: %DataTx{type: ChannelCloseMutalTx}} = tx) do
+  def new_tx_mined(%SignedTx{data: %DataTx{type: ChannelCloseMutualTx}} = tx) do
     closed(tx)
   end
 
@@ -137,7 +136,7 @@ defmodule Aecore.Channel.Worker do
   end
 
   @doc """
-  Creates open transaction. Can only be called once per channel by :initiator. Returns pair: generated channelID, half signed SignedTx.
+  Creates open transaction. Can only be called once per channel by :initiator. Returns pair: generated channel_id, half signed SignedTx.
   """
   @spec open(
           binary(),
@@ -235,7 +234,7 @@ defmodule Aecore.Channel.Worker do
   end
 
   @doc """
-  Handles incoming uncorfirmed fully signed onchain Tx or confirmed fully signed offchain Tx.
+  Handles incoming unconfirmed fully signed onchain Tx or confirmed fully signed offchain Tx.
   """
   @spec receive_fully_signed_tx(ChannelTransaction.channel_tx()) :: :ok | error()
   def receive_fully_signed_tx(fully_signed_tx) do
@@ -563,7 +562,7 @@ defmodule Aecore.Channel.Worker do
   def handle_call({:closed, %SignedTx{data: %DataTx{payload: payload}}}, _from, state) do
     id =
       case payload do
-        %ChannelCloseMutalTx{channel_id: id} ->
+        %ChannelCloseMutualTx{channel_id: id} ->
           id
 
         %ChannelSettleTx{channel_id: id} ->

--- a/apps/aecore/lib/aecore/keys/keys.ex
+++ b/apps/aecore/lib/aecore/keys/keys.ex
@@ -88,7 +88,7 @@ defmodule Aecore.Keys do
   the function will return the miners :sign and :peer keypair. If a suffix is added,
   additional keypairs are going to be returned.
 
-  The accepter keypair types are:
+  The accepted keypair types are:
     * `:sign` - returns a tuple with signing keys {pub, priv}
     * `:peer` - returns a tuple with peers keys {pub, priv}
 
@@ -153,7 +153,7 @@ defmodule Aecore.Keys do
   defp gen_dir(false, keys_dir), do: File.mkdir!(keys_dir)
   defp gen_dir(true, _), do: :ok
 
-  # Reads the keys from their respectve directory and returns
+  # Reads the keys from their respective directory and returns
   # their decrypted result. If either of the files is not readable - return an error
   defp read_keypair(pwd, pub_file, priv_file) do
     case {File.read(pub_file), File.read(priv_file)} do

--- a/apps/aecore/lib/aecore/naming/tx/name_claim_tx.ex
+++ b/apps/aecore/lib/aecore/naming/tx/name_claim_tx.ex
@@ -151,7 +151,7 @@ defmodule Aecore.Naming.Tx.NameClaimTx do
          }"}
 
       claim != :none ->
-        {:error, "#{__MODULE__}: Name has aleady been claimed: #{inspect(claim)}"}
+        {:error, "#{__MODULE__}: Name has already been claimed: #{inspect(claim)}"}
 
       true ->
         :ok

--- a/apps/aecore/lib/aecore/naming/tx/name_transfer_tx.ex
+++ b/apps/aecore/lib/aecore/naming/tx/name_transfer_tx.ex
@@ -40,7 +40,7 @@ defmodule Aecore.Naming.Tx.NameTransferTx do
   @doc """
   Definition of the NameTransferTx structure
   # Parameters
-  - hash: hash of name to be transfered
+  - hash: hash of name to be transferred
   - target: target public key to transfer to
   """
   defstruct [:hash, :target]

--- a/apps/aecore/lib/aecore/oracle/tx/oracle_query_tx.ex
+++ b/apps/aecore/lib/aecore/oracle/tx/oracle_query_tx.ex
@@ -120,7 +120,7 @@ defmodule Aecore.Oracle.Tx.OracleQueryTx do
         {:error, "#{__MODULE__}: Invalid oracle identifier: #{inspect(oracle_address)}"}
 
       !Keys.key_size_valid?(address) ->
-        {:error, "#{__MODULE__}: oracle_adddress size invalid"}
+        {:error, "#{__MODULE__}: oracle_address size invalid"}
 
       length(senders) != 1 ->
         {:error, "#{__MODULE__}: Invalid senders number"}

--- a/apps/aecore/lib/aecore/oracle/tx/oracle_registration_tx.ex
+++ b/apps/aecore/lib/aecore/oracle/tx/oracle_registration_tx.ex
@@ -82,7 +82,7 @@ defmodule Aecore.Oracle.Tx.OracleRegistrationTx do
         {:error, "#{__MODULE__}: Invalid query or response format definition"}
 
       !Oracle.ttl_is_valid?(ttl) ->
-        {:error, "#{__MODULE__}: Invald ttl"}
+        {:error, "#{__MODULE__}: Invalid ttl"}
 
       length(senders) != 1 ->
         {:error, "#{__MODULE__}: Invalid senders number"}

--- a/apps/aecore/lib/aecore/peers/peer_connection.ex
+++ b/apps/aecore/lib/aecore/peers/peer_connection.ex
@@ -438,7 +438,7 @@ defmodule Aecore.Peers.PeerConnection do
   end
 
   def rlp_decode(@p2p_response, encoded_response) do
-    # vsn should be addititonaly decoded with :binary.decode_unsigned
+    # vsn should be additionally decoded with :binary.decode_unsigned
     [_vsn, result, type, reason, object] = ExRLP.decode(encoded_response)
     deserialized_result = bool_bin(result)
 
@@ -472,7 +472,7 @@ defmodule Aecore.Peers.PeerConnection do
 
   def rlp_decode(@ping, encoded_ping) do
     [
-      # vsn should be addititonaly decoded with :binary.decode_unsigned
+      # vsn should be additionally decoded with :binary.decode_unsigned
       _vsn,
       port,
       share,
@@ -493,13 +493,13 @@ defmodule Aecore.Peers.PeerConnection do
   end
 
   def rlp_decode(@get_header_by_hash, encoded_get_header_by_hash) do
-    # vsn should be addititonaly decoded with :binary.decode_unsigned
+    # vsn should be additionally decoded with :binary.decode_unsigned
     [_vsn, hash] = ExRLP.decode(encoded_get_header_by_hash)
     %{hash: hash}
   end
 
   def rlp_decode(@get_header_by_height, encoded_get_header_by_height) do
-    # vsn should be addititonaly decoded with :binary.decode_unsigned
+    # vsn should be additionally decoded with :binary.decode_unsigned
     [
       _vsn,
       height,
@@ -511,7 +511,7 @@ defmodule Aecore.Peers.PeerConnection do
 
   def rlp_decode(@header, encoded_header) do
     [
-      # vsn should be addititonaly decoded with :binary.decode_unsigned
+      # vsn should be additionally decoded with :binary.decode_unsigned
       _vsn,
       header_binary
     ] = ExRLP.decode(encoded_header)

--- a/apps/aecore/lib/aecore/persistence/worker.ex
+++ b/apps/aecore/lib/aecore/persistence/worker.ex
@@ -13,9 +13,9 @@ defmodule Aecore.Persistence.Worker do
 
   @typedoc """
   To operate with a patricia merkle tree
-  we do need db reference
+  we need a db reference
 
-  Those names referes to the keys into patricia_families
+  Those names refer to the keys in the patricia_families
   map in our state
   """
 

--- a/apps/aecore/lib/aecore/poi/poi.ex
+++ b/apps/aecore/lib/aecore/poi/poi.ex
@@ -1,7 +1,7 @@
 defmodule Aecore.Poi.Poi do
   @moduledoc """
   Module implementing a Proof of Inclusion(POI) on state trees for the entire chainstate.
-  The POI is an abstraction for sharing and accesing a subset of an existing chainstate to any intrested party.
+  The POI is an abstraction for sharing and accessing a subset of an existing chainstate to any interested party.
   The POI is cryptographically tied to the chainstate from which the POI was generated (we can proof that the POI is a subset of a chainstate with a given state hash).
   """
 

--- a/apps/aecore/lib/aecore/poi/poi_proof.ex
+++ b/apps/aecore/lib/aecore/poi/poi_proof.ex
@@ -1,8 +1,8 @@
 defmodule Aecore.Poi.PoiProof do
   @moduledoc """
-  Implements a Proof Of Inclusion(POI) for a single Merkle Patricia Trie. This module is type agnostic, any keys or values passed to this module must be serialized beforehand. This is an abstraction layer for providing a view into a subset of a given merkle patricia trie. The POI is cryptographicaly tied to the original merkle patricia tree - we can cryptographicly proof that the POI was generated from a merkle patricia trie with a given root hash.
+  Implements a Proof Of Inclusion(POI) for a single Merkle Patricia Trie. This module is type agnostic, any keys or values passed to this module must be serialized beforehand. This is an abstraction layer for providing a view into a subset of a given merkle patricia trie. The POI is cryptographically tied to the original merkle patricia tree - we can cryptographically proof that the POI was generated from a merkle patricia trie with a given root hash.
 
-  Standard merkle patricia tries rely on a persistent key value store which is accesed by callbacks. This module uses a in memory map as the key value store and uses the PoiPersistence wrapper in order to encapsulate the side effects of the PatriciaMerkleTree module.
+  Standard merkle patricia tries rely on a persistent key value store which is accessed by callbacks. This module uses a in memory map as the key value store and uses the PoiPersistence wrapper in order to encapsulate the side effects of the PatriciaMerkleTree module.
   """
 
   alias Aecore.Poi.PoiPersistence
@@ -155,7 +155,7 @@ defmodule Aecore.Poi.PoiProof do
     )
   end
 
-  # Wrapper for proof construction on merkle patricia trees. Uses the PoiPersistence wrapper for obtaining functional behaviour although the underlaying library relies on side effects in order to achieve persistence.
+  # Wrapper for proof construction on merkle patricia trees. Uses the PoiPersistence wrapper for obtaining functional behaviour although the underlying library relies on side effects in order to achieve persistence.
   @spec side_efects_encapsulating_proof_construction(PoiProof.t(), Trie.t(), Trie.key()) ::
           {:ok, Trie.value(), map()} | {:error, :key_not_found}
   defp side_efects_encapsulating_proof_construction(%PoiProof{} = poi_proof, %Trie{} = trie, key) do
@@ -202,7 +202,7 @@ defmodule Aecore.Poi.PoiProof do
   end
 
   @doc """
-  Lookups the entry assiociated with the given key in the Poi proof
+  Lookups the entry associated with the given key in the Poi proof
   """
   @spec lookup_in_poi(PoiProof.t(), Trie.key()) :: {:ok, Trie.value()} | :error
   def lookup_in_poi(%PoiProof{} = poi_proof, key) do
@@ -230,7 +230,7 @@ defmodule Aecore.Poi.PoiProof do
   end
 
   @doc """
-  Deserialized the poi proof from a list
+  Deserializes the poi proof from a list
   """
   @spec decode_from_list(list(list(binary()))) :: {:ok, PoiProof.t()} | {:error, String.t()}
   def decode_from_list([]) do

--- a/apps/aecore/lib/aecore/pow/cuckoo.ex
+++ b/apps/aecore/lib/aecore/pow/cuckoo.ex
@@ -1,6 +1,6 @@
 defmodule Aecore.Pow.Cuckoo do
   @moduledoc """
-  A library providing Cuckoo Cycle PoW generation and verification.
+  A librarye providing Cuckoo Cycle PoW generation and verification.
   John Tromp:  https://github.com/tromp/cuckoo
   White paper: https://github.com/tromp/cuckoo/blob/master/doc/cuckoo.pdf?raw=true
 

--- a/apps/aecore/lib/aecore/pow/cuckoo.ex
+++ b/apps/aecore/lib/aecore/pow/cuckoo.ex
@@ -1,6 +1,6 @@
 defmodule Aecore.Pow.Cuckoo do
   @moduledoc """
-  A librarye providing Cuckoo Cycle PoW generation and verification.
+  A library providing Cuckoo Cycle PoW generation and verification.
   John Tromp:  https://github.com/tromp/cuckoo
   White paper: https://github.com/tromp/cuckoo/blob/master/doc/cuckoo.pdf?raw=true
 

--- a/apps/aecore/lib/aecore/pow/mock.ex
+++ b/apps/aecore/lib/aecore/pow/mock.ex
@@ -1,6 +1,6 @@
 defmodule Aecore.Pow.Mock do
   @moduledoc """
-  Provides a mock proofd of work that always succeeds generation and uses predefined integers as proof. In validation checks that integers are as expected
+  Provides a mock proof of work that always succeeds generation and uses predefined integers as proof. In validation checks that integers are as expected
   """
 
   alias Aecore.Chain.Header

--- a/apps/aecore/lib/aecore/pow/mock.ex
+++ b/apps/aecore/lib/aecore/pow/mock.ex
@@ -1,6 +1,6 @@
 defmodule Aecore.Pow.Mock do
   @moduledoc """
-  Provides a mock proof of work that always succeeds generation and uses predefined integers as proof. In validation checks that integers are as expected
+  Provides a mock proofd of work that always succeeds generation and uses predefined integers as proof. In validation checks that integers are as expected
   """
 
   alias Aecore.Chain.Header

--- a/apps/aecore/lib/aecore/pow/pow.ex
+++ b/apps/aecore/lib/aecore/pow/pow.ex
@@ -1,6 +1,6 @@
 defmodule Aecore.Pow.Pow do
   @moduledoc """
-  A meta Proof of work alorithm that invokes proper allgorithm for current environment
+  A meta Proof of work algorithm that invokes proper algorithm for current environment
   """
 
   alias Aecore.Chain.Header
@@ -8,7 +8,7 @@ defmodule Aecore.Pow.Pow do
   @behaviour Aecore.Pow.PowAlgorithm
 
   @doc """
-  Calls verify of apropriate module
+  Calls verify of appropriate module
   """
   @spec verify(Header.t()) :: boolean()
   def verify(%Header{} = header) do
@@ -16,7 +16,7 @@ defmodule Aecore.Pow.Pow do
   end
 
   @doc """
-  Calls generate of apropriate module
+  Calls generate of appropriate module
   """
   @spec generate(Header.t()) :: {:ok, Header.t()}
   def generate(%Header{} = header) do

--- a/apps/aecore/lib/aecore/pow/pow_algorithm.ex
+++ b/apps/aecore/lib/aecore/pow/pow_algorithm.ex
@@ -13,7 +13,7 @@ defmodule Aecore.Pow.PowAlgorithm do
   @callback verify(Header.t()) :: boolean()
 
   @doc """
-  Creates a pow_evidence. Returns a Header with pow_evidence field filld or error.
+  Creates a pow_evidence. Returns a Header with pow_evidence field filled or error.
   pow_evidence has to be a list of 42 integers.
   """
   @callback generate(Header.t()) :: {:ok, Header.t()} | error()

--- a/apps/aecore/lib/aecore/sync/sync.ex
+++ b/apps/aecore/lib/aecore/sync/sync.ex
@@ -100,7 +100,7 @@ defmodule Aecore.Sync.Sync do
   ## 1. It has worst top hash than our node, do not include in sync
   ## 2. It has better top hash than our node
   ##    We binary search for a block that we agree upon (could be genesis)
-  ## We add new node to sync pool to sync agreed block upto top of new
+  ## We add new node to sync pool to sync agreed block up to top of new
   ## 1. If we are already synchronizing, we ignore it,
   ##    the ongoing sync will pick that up later
   ## 2. If we are not already synchronizing, we start doing so.
@@ -231,7 +231,7 @@ defmodule Aecore.Sync.Sync do
   @doc """
   Try matching this chain to already existent Task.
   If this chain doesn't match any task chain, then we
-  create a seperate task for it. (This chain is probably a fork)
+  create a separate task for it. (This chain is probably a fork)
   """
   @spec sync_task_for_chain(Chain.t(), Sync.t()) ::
           {:inconclusive, Chain.t(), {:get_header, chain_id(), peer_id(), block_height()}}
@@ -323,7 +323,7 @@ defmodule Aecore.Sync.Sync do
   @doc """
   Get all elements of the pool where the block is already taken from
   the peer (the third element is not false)
-  untill reaching an element whose block hasn't been picked yet.
+  until reaching an element whose block hasn't been picked yet.
   """
   @spec split_pool(list(Task.pool_elem())) ::
           {list(Task.pool_elem()), list(Task.pool_elem()) | []}
@@ -427,7 +427,7 @@ defmodule Aecore.Sync.Sync do
   end
 
   @doc """
-  Handle new worker or change of a proccess related to worker.
+  Handle new worker or change of a process related to worker.
   """
   @spec do_handle_worker(
           {:new_worker, peer_id(), pid()}

--- a/apps/aecore/lib/aecore/sync/task.ex
+++ b/apps/aecore/lib/aecore/sync/task.ex
@@ -1,7 +1,7 @@
 defmodule Aecore.Sync.Task do
   @moduledoc """
   Each sync task holds information about a syncing process with multiple peers 
-  where each peer is recognized as a worker with peer_id and pid of a seperate process doing the work.
+  where each peer is recognized as a worker with peer_id and pid of a separate process doing the work.
   A sync task works on a specific chain, meaning there is one sync task per chain.
   If a worker is on different chain (on a fork, meaning different chain than what we already syncing against)
   a new sync task will be started. In the normal case where all is good 

--- a/apps/aecore/lib/aecore/tx/data_tx.ex
+++ b/apps/aecore/lib/aecore/tx/data_tx.ex
@@ -26,7 +26,7 @@ defmodule Aecore.Tx.DataTx do
           | Aecore.Contract.Tx.ContractCreateTx
           | Aecore.Contract.Tx.ContractCallTx
           | Aecore.Channel.Tx.ChannelCreateTx
-          | Aecore.Channel.Tx.ChannelCloseMutalTx
+          | Aecore.Channel.Tx.ChannelCloseMutualTx
           | Aecore.Channel.Tx.ChannelCloseSoloTx
           | Aecore.Channel.Tx.ChannelSlashTx
           | Aecore.Channel.Tx.ChannelSettleTx
@@ -48,7 +48,7 @@ defmodule Aecore.Tx.DataTx do
           | Aecore.Contract.Tx.ContractCreateTx.t()
           | Aecore.Contract.Tx.ContractCallTx.t()
           | Aecore.Channel.Tx.ChannelCreateTx.t()
-          | Aecore.Channel.Tx.ChannelCloseMutalTx.t()
+          | Aecore.Channel.Tx.ChannelCloseMutualTx.t()
           | Aecore.Channel.Tx.ChannelCloseSoloTx.t()
           | Aecore.Channel.Tx.ChannelSlashTx.t()
           | Aecore.Channel.Tx.ChannelSettleTx.t()
@@ -75,7 +75,7 @@ defmodule Aecore.Tx.DataTx do
 
   # Parameters
   - type: The type of transaction that may be added to the blockchain
-  - payload: The strcuture of the specified transaction type
+  - payload: The structure of the specified transaction type
   - senders: The public addresses of the accounts originating the transaction. First element of this list is special - it's the main sender. Nonce is applied to main sender Account.
   - fee: The amount of tokens given to the miner
   - nonce: An integer bigger then current nonce of main sender Account. (see senders)
@@ -99,7 +99,7 @@ defmodule Aecore.Tx.DataTx do
       Aecore.Contract.Tx.ContractCallTx,
       Aecore.Channel.Tx.ChannelCreateTx,
       Aecore.Channel.Tx.ChannelCloseSoloTx,
-      Aecore.Channel.Tx.ChannelCloseMutalTx,
+      Aecore.Channel.Tx.ChannelCloseMutualTx,
       Aecore.Channel.Tx.ChannelSlashTx,
       Aecore.Channel.Tx.ChannelSettleTx,
       Aecore.Channel.Tx.ChannelWithdrawTx,

--- a/apps/aecore/lib/aecore/tx/transaction.ex
+++ b/apps/aecore/lib/aecore/tx/transaction.ex
@@ -41,7 +41,7 @@ defmodule Aecore.Tx.Transaction do
           | Aecore.Contract.Tx.ContractCreateTx.t()
           | Aecore.Contract.Tx.ContractCallTx.t()
           | Aecore.Channel.Tx.ChannelCreateTx.t()
-          | Aecore.Channel.Tx.ChannelCloseMutalTx.t()
+          | Aecore.Channel.Tx.ChannelCloseMutualTx.t()
           | Aecore.Channel.Tx.ChannelCloseSoloTx.t()
           | Aecore.Channel.Tx.ChannelSlashTx.t()
           | Aecore.Channel.Tx.ChannelSettleTx.t()

--- a/apps/aecore/test/aecore_channels_compatibility_test.exs
+++ b/apps/aecore/test/aecore_channels_compatibility_test.exs
@@ -12,7 +12,7 @@ defmodule AecoreChannelCompatibilityTest do
   alias Aecore.Channel.Worker, as: Channels
 
   alias Aecore.Channel.Tx.{
-    ChannelCloseMutalTx,
+    ChannelCloseMutualTx,
     ChannelSettleTx
   }
 
@@ -155,7 +155,7 @@ defmodule AecoreChannelCompatibilityTest do
 
     tx =
       DataTx.init(
-        ChannelCloseMutalTx,
+        ChannelCloseMutualTx,
         %{
           channel_id: id,
           initiator_amount: initiator_amount,

--- a/apps/aecore/test/aecore_channels_compatibility_test.exs
+++ b/apps/aecore/test/aecore_channels_compatibility_test.exs
@@ -294,7 +294,7 @@ defmodule AecoreChannelCompatibilityTest do
 
     assert_offchain_txs_equal(fully_signed_transfer_tx2, epoch_transfer2)
 
-    # close mutal
+    # close mutual
 
     epoch_mutal_close_tx =
       Bits.decode58(

--- a/apps/aecore/test/aecore_channels_test.exs
+++ b/apps/aecore/test/aecore_channels_test.exs
@@ -265,7 +265,7 @@ defmodule AecoreChannelTest do
     # slashing with old state fails
     assert_custom_tx_fails(solo_close_tx2)
 
-    # make some transfers so the solo_close tx will include a OffchainTx
+    # make some transfers so the solo_close tx will include a OffChainTx
     perform_transfer(id, 25, &call_s2/1, ctx.sk2, &call_s1/1, ctx.sk1)
     assert_offchain_state(id, 75, 225, 8)
 

--- a/apps/aecore/test/aecore_naming_test.exs
+++ b/apps/aecore/test/aecore_naming_test.exs
@@ -97,7 +97,7 @@ defmodule AecoreNamingTest do
     assert first_name_transfer.status == :claimed
     assert first_name_transfer.pointers == "{\"test\": 2}"
 
-    # fund transfered account
+    # fund transferred account
     Account.spend(transfer_to_pub, 5, 5, <<"payload">>)
     Miner.mine_sync_block_to_chain()
 
@@ -402,7 +402,7 @@ defmodule AecoreNamingTest do
     assert first_name_transfer.status == :claimed
     assert first_name_transfer.pointers == "{\"test\": 2}"
 
-    # fund transfered account
+    # fund transferred account
     Account.spend(transfer_to_pub, 5, 5, <<"payload">>)
     Miner.mine_sync_block_to_chain()
 

--- a/apps/aecore/test/aecore_persistence_test.exs
+++ b/apps/aecore/test/aecore_persistence_test.exs
@@ -55,7 +55,7 @@ defmodule PersistenceTest do
     # For specific account
     assert match?(%{balance: ^correct_balance}, get_account_state(persistance_state.account1))
 
-    # Non existant accounts are empty
+    # Non existing accounts are empty
     assert :not_found = get_account_state(persistance_state.account2)
 
     # For all accounts

--- a/apps/aecore/test/aecore_poi_epoch_compatibility_and_functional_test.exs
+++ b/apps/aecore/test/aecore_poi_epoch_compatibility_and_functional_test.exs
@@ -195,7 +195,7 @@ defmodule PoiEpochCompabilityTest do
     poi = Poi.construct(chainstate)
     assert root_hash === Poi.calculate_root_hash(poi)
 
-    # In the begining there are no accounts in the Poi
+    # In the beginning there are no accounts in the Poi
     test_poi(poi, [], included_accounts ++ excluded_accounts)
 
     # Add accounts to the Poi one by one and test if they are properly included in the Poi

--- a/apps/aecore/test/aecore_tx_test.exs
+++ b/apps/aecore/test/aecore_tx_test.exs
@@ -85,7 +85,7 @@ defmodule AecoreTxTest do
     assert Account.balance(Chain.chain_state().accounts, sender) == amount
 
     :ok = Miner.mine_sync_block_to_chain()
-    # At this poing the sender should have (reward * 3) tokens,
+    # At this point the sender should have (reward * 3) tokens,
     # enough to mine the transaction in the pool
 
     assert Account.balance(Chain.chain_state().accounts, sender) == reward * 3

--- a/apps/aecore/test/aecore_validation_test.exs
+++ b/apps/aecore/test/aecore_validation_test.exs
@@ -66,7 +66,7 @@ defmodule AecoreValidationTest do
 
     incorrect_pow_block = %Block{new_block | header: %Header{new_block.header | height: 10}}
 
-    assert {:error, "#{BlockValidation}: Header hash doesnt meet the target"} ==
+    assert {:error, "#{BlockValidation}: Header hash doesn't meet the target"} ==
              BlockValidation.calculate_and_validate_block(
                incorrect_pow_block,
                prev_block,

--- a/apps/aecore/test/multiple_transactions_test.exs
+++ b/apps/aecore/test/multiple_transactions_test.exs
@@ -91,7 +91,7 @@ defmodule MultipleTransactionsTest do
     Pool.get_and_empty_pool()
     assert 100 == Account.balance(TestUtils.get_accounts_chainstate(), account2_pub_key)
 
-    # acccount2 => 100; account3 => 90
+    # account2 => 100; account3 => 90
 
     # account2 has 100 tokens, spends 30 (+10 fee) to account3,
     # and two times 20 (+10 fee) to account4 should succeed

--- a/apps/aetestframework/lib/worker.ex
+++ b/apps/aetestframework/lib/worker.ex
@@ -34,8 +34,8 @@ defmodule Aetestframework.Worker do
 
   @doc """
   Post a command to a specific node.
-  Used to send command that will return some response and we n(eed to
-  handle it. Like getting the top header hash
+  Used to send commands which will return some response that we need to
+  process. Like getting the top header hash
   """
   @spec get(String.t(), atom(), atom(), non_neg_integer()) :: any()
   def get(cmd, match_by, node, timeout \\ @default_timeout) do

--- a/apps/aeutil/lib/patricia_merkle_tree.ex
+++ b/apps/aeutil/lib/patricia_merkle_tree.ex
@@ -1,8 +1,8 @@
 defmodule Aeutil.PatriciaMerkleTree do
   @moduledoc """
 
-  This module provides apis for creating, updating, deleting
-  patricia merkle tries, The actual handler is https://github.com/exthereum/merkle_patricia_tree
+  This module provides and API for creating, updating, deleting
+  patricia merkle tries, The actual handler is https://github.com/aeternity/elixir-merkle-patricia-tree
 
   """
 
@@ -16,7 +16,7 @@ defmodule Aeutil.PatriciaMerkleTree do
 
   @typedoc """
   Depending on the name, different data base ref will
-  be used for the trie creaton.
+  be used for the trie creation.
   """
   @type trie_name ::
           :accounts

--- a/apps/aeutil/lib/scientific.ex
+++ b/apps/aeutil/lib/scientific.ex
@@ -62,7 +62,7 @@ defmodule Aeutil.Scientific do
 
   # The Difficulty is calculated from the Target and is used in Sync.
   # Difficulty is used to select the winning fork of new blocks:
-  # the difficulty of chain of blocks is the sum of the diffculty of each block.
+  # the difficulty of chain of blocks is the sum of the difficulty of each block.
 
   @spec target_to_difficulty(non_neg_integer()) :: float()
   def target_to_difficulty(target) do

--- a/apps/aeutil/lib/serialization.ex
+++ b/apps/aeutil/lib/serialization.ex
@@ -41,7 +41,7 @@ defmodule Aeutil.Serialization do
   def base64_binary(_, _), do: nil
 
   @doc """
-  Loops through a structure are simplifies it. Removes all the strucutured maps
+  Loops through a structure and simplifies it. Removes all the structured maps
   """
   @spec remove_struct(list()) :: list()
   def remove_struct(term) when is_list(term) do
@@ -72,7 +72,7 @@ defmodule Aeutil.Serialization do
   end
 
   @doc """
-  Initializing function to the recursive functionality of serializing a strucure
+  Initializing function to the recursive functionality of serializing a structure
   """
   @spec serialize_value(value()) :: value()
   def serialize_value(value), do: serialize_value(value, "")
@@ -171,7 +171,7 @@ defmodule Aeutil.Serialization do
   def serialize_value(value, _), do: value
 
   @doc """
-  Initializing function to the recursive functionality of deserializing a strucure
+  Initializing function to the recursive functionality of deserializing a structure
   """
   @spec deserialize_value(value()) :: value()
   def deserialize_value(value), do: deserialize_value(value, :other)
@@ -350,7 +350,7 @@ defmodule Aeutil.Serialization do
         ExRLP.decode(binary)
       rescue
         e ->
-          {:error, "#{__MODULE__}: rlp_decode: IIllegal serialization: #{Exception.message(e)}"}
+          {:error, "#{__MODULE__}: rlp_decode: Illegal serialization: #{Exception.message(e)}"}
       end
 
     case result do

--- a/apps/aeutil/lib/type_to_tag.ex
+++ b/apps/aeutil/lib/type_to_tag.ex
@@ -28,7 +28,7 @@ defmodule Aeutil.TypeToTag do
   def tag_to_type(51), do: {:ok, Aecore.Channel.Tx.ChannelDepositTx}
   def tag_to_type(52), do: {:ok, Aecore.Channel.Tx.ChannelWithdrawTx}
   # Channel force progress transaction - 521
-  def tag_to_type(53), do: {:ok, Aecore.Channel.Tx.ChannelCloseMutalTx}
+  def tag_to_type(53), do: {:ok, Aecore.Channel.Tx.ChannelCloseMutualTx}
   def tag_to_type(54), do: {:ok, Aecore.Channel.Tx.ChannelCloseSoloTx}
   def tag_to_type(55), do: {:ok, Aecore.Channel.Tx.ChannelSlashTx}
   def tag_to_type(56), do: {:ok, Aecore.Channel.Tx.ChannelSettleTx}
@@ -70,7 +70,7 @@ defmodule Aeutil.TypeToTag do
   def type_to_tag(Aecore.Channel.Tx.ChannelDepositTx), do: {:ok, 51}
   def type_to_tag(Aecore.Channel.Tx.ChannelWithdrawTx), do: {:ok, 52}
   # Channel force progress transaction - 521
-  def type_to_tag(Aecore.Channel.Tx.ChannelCloseMutalTx), do: {:ok, 53}
+  def type_to_tag(Aecore.Channel.Tx.ChannelCloseMutualTx), do: {:ok, 53}
   def type_to_tag(Aecore.Channel.Tx.ChannelCloseSoloTx), do: {:ok, 54}
   def type_to_tag(Aecore.Channel.Tx.ChannelSlashTx), do: {:ok, 55}
   def type_to_tag(Aecore.Channel.Tx.ChannelSettleTx), do: {:ok, 56}

--- a/apps/aevm/lib/gas_codes.ex
+++ b/apps/aevm/lib/gas_codes.ex
@@ -46,8 +46,8 @@ defmodule Aevm.GasCodes do
   # non-zero from zero.
   defmacro _GSSET do quote do: 20000 end
 
-  # Paid for an SSTORE operation when the storage value’s zeroness
-  # remains unchanged or is set to zero.
+  # Paid for an SSTORE operation when the storage value
+  # remains zero or is set to zero.
   defmacro _GSRESET do quote do: 5000 end
 
   # Refund given (added into refund counter) when the storage value is
@@ -86,7 +86,7 @@ defmodule Aevm.GasCodes do
 
   # Partial payment when multiplied by dlog256(exponent)e for the EXP
   # operation.
-  defmacro _GEXPBYTE do quote do: 10 end # From the go implementation. 50 from the yellopaper
+  defmacro _GEXPBYTE do quote do: 10 end # From the go implementation. 50 from the yellow paper
 
   # Paid for every additional word when expanding memory.
   defmacro _GMEMORY do quote do: 3 end

--- a/apps/aevm/lib/stack.ex
+++ b/apps/aevm/lib/stack.ex
@@ -20,7 +20,7 @@ defmodule Aevm.Stack do
   def pop(%{stack: stack} = state) do
     case stack do
       [arg | stack] -> {arg, State.set_stack(stack, state)}
-      [] -> throw({:error, "emtpy_stack", stack})
+      [] -> throw({:error, "empty_stack", stack})
     end
   end
 

--- a/spell_check_diff_master.sh
+++ b/spell_check_diff_master.sh
@@ -1,0 +1,29 @@
+#/usr/bin/env bash
+
+function filter_codebase {
+find . -iname "*.ex" -o -iname "*.exs" | grep "/lib/" | grep -v deps | grep -v _build | xargs -I cmd sh -c "cat cmd | nl -ba -w 1 | sed 's@^[0-9]*@cmd:&@'" | pcregrep -M "\"\"\".*?(\n|.)*?.*?\"\"\"|#[^{].*?\n|:error, \"(\n|.)*?\"" | sort > $1
+}
+
+ORIG=$(git branch | grep \* | cut -d ' ' -f2);
+
+filter_codebase /tmp/spell_orig;
+
+git stash;
+git checkout master;
+git reset --hard master;
+
+filter_codebase /tmp/spell_master;
+
+# https://stackoverflow.com/questions/18204904/fast-way-of-finding-lines-in-one-file-that-are-not-in-another
+diff --new-line-format="" --unchanged-line-format=""  /tmp/spell_orig /tmp/spell_master > /tmp/spell;
+
+git checkout $ORIG;
+git stash apply;
+git stash drop;
+
+rm /tmp/spell_orig;
+rm /tmp/spell_master;
+
+aspell -l en -d en -c /tmp/spell;
+
+rm /tmp/spell;

--- a/spell_check_diff_master.sh
+++ b/spell_check_diff_master.sh
@@ -1,7 +1,7 @@
 #/usr/bin/env bash
 
 function filter_codebase {
-find . -iname "*.ex" -o -iname "*.exs" | grep "/lib/" | grep -v deps | grep -v _build | xargs -I cmd sh -c "cat cmd | nl -ba -w 1 | sed 's@^[0-9]*@cmd:&@'" | pcregrep -M "\"\"\".*?(\n|.)*?.*?\"\"\"|#[^{].*?\n|:error, \"(\n|.)*?\"" | sort > $1
+find . -iname "*.ex" -o -iname "*.exs" | grep -E "/lib/|/test/|/config/" | grep -v deps | grep -v _build | xargs -I cmd sh -c "cat cmd | nl -ba -w 1 | sed 's@^[0-9]*@cmd:&@'" | pcregrep -M "\"\"\".*?(\n|.)*?.*?\"\"\"|#[^{].*?\n|:error, \"(\n|.)*?\"" | sort > $1
 }
 
 ORIG=$(git branch | grep \* | cut -d ' ' -f2);

--- a/spell_check_entire_codebase.sh
+++ b/spell_check_entire_codebase.sh
@@ -1,0 +1,4 @@
+#/usr/bin/env bash
+
+find . -iname "*.ex" -o -iname "*.exs" | grep "/lib/" | grep -v deps | grep -v _build | xargs -I cmd sh -c "cat cmd | nl -ba -w 1 | sed 's@^[0-9]*@cmd:&@'" | pcregrep -M "\"\"\".*?(\n|.)*?.*?\"\"\"|#[^{].*?\n|:error, \"(\n|.)*?\"" > /tmp/spell; aspell -l en -d en -c /tmp/spell; rm /tmp/spell;
+

--- a/spell_check_entire_codebase.sh
+++ b/spell_check_entire_codebase.sh
@@ -1,4 +1,4 @@
 #/usr/bin/env bash
 
-find . -iname "*.ex" -o -iname "*.exs" | grep "/lib/" | grep -v deps | grep -v _build | xargs -I cmd sh -c "cat cmd | nl -ba -w 1 | sed 's@^[0-9]*@cmd:&@'" | pcregrep -M "\"\"\".*?(\n|.)*?.*?\"\"\"|#[^{].*?\n|:error, \"(\n|.)*?\"" > /tmp/spell; aspell -l en -d en -c /tmp/spell; rm /tmp/spell;
+find . -iname "*.ex" -o -iname "*.exs" | grep -E "/lib/|/test/|/config/" | grep -v deps | grep -v _build | xargs -I cmd sh -c "cat cmd | nl -ba -w 1 | sed 's@^[0-9]*@cmd:&@'" | pcregrep -M "\"\"\".*?(\n|.)*?.*?\"\"\"|#[^{].*?\n|:error, \"(\n|.)*?\"" > /tmp/spell; aspell -l en -d en -c /tmp/spell; rm /tmp/spell;
 


### PR DESCRIPTION
I've spell checked our entire code base using aspell and removed a lot of typos.

The PR includes bash scripts for spellchecking the entire code base and spellchecking the difference between the current and master branch. The scripts require that aspell(interactive spell checker) and pcregrep(grep with Perl-compatible regular expressions) is installed.