### PR TITLE
[GH-721] Miner crash workaround

### DIFF
--- a/apps/aecore/lib/aecore/pow/cuckoo.ex
+++ b/apps/aecore/lib/aecore/pow/cuckoo.ex
@@ -89,7 +89,8 @@ defmodule Aecore.Pow.Cuckoo do
       {:sync, false},
       {:cd, full_bin_dir},
       {:env, [{"SHELL", "/bin/sh"}]},
-      {:monitor, true}
+      {:monitor, true},
+      {:pty, false}
     ]
   end
 


### PR DESCRIPTION
This PR will prevent the miner from crashing on long runs.
I've tried to find the underlying reason for the crashes but I couldn't find it. It seems that very rarely in the multi threaded native miner a race condition occurs which crashes the miner. I've added the functionality of ignoring these crashes.

resolves #721 